### PR TITLE
parameterize keycloak realm and client, backend fixes

### DIFF
--- a/backend/api/fixtures/operational/0005_add_plugin_hybrid_vehicles.py
+++ b/backend/api/fixtures/operational/0005_add_plugin_hybrid_vehicles.py
@@ -25,84 +25,68 @@ class AddPluginHybridVehicles(OperationalDataScript):
     def run(self):
         model_year = ModelYear.objects.get(name="2019")
         make = Make.objects.get(name="BMW")
-        model = Model.objects.create(
-            name="530e",
-            make=make
-        )
+        model = "530e"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BZ"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="26",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="C")
         )
 
-        model = Model.objects.create(
-            name="530e xDRIVE",
-            make=make
-        )
+        model = "530e xDRIVE"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BZ"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="24",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="C")
         )
 
-        model = Model.objects.create(
-            name="i3 REx (120 Ah)",
-            make=make
-        )
+        model = "i3 REx (120 Ah)"
+
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BZ"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="203",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="S")
         )
 
-        model = Model.objects.create(
-            name="i3s REx (120 Ah)",
-            make=make
-        )
+        model = "i3s REx (120 Ah)"
+
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BZ"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="203",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="S")
         )
 
-        model = Model.objects.create(
-            name="i8 COUPE",
-            make=make
-        )
+        model = "i8 COUPE"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BZ"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="29",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="S")
         )
 
-        model = Model.objects.create(
-            name="i8 ROADSTER",
-            make=make
-        )
+        model = "i8 ROADSTER"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BZ"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="29",
             state="VALIDATED",
@@ -110,14 +94,11 @@ class AddPluginHybridVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Chevrolet")
-        model = Model.objects.create(
-            name="VOLT",
-            make=make
-        )
+        model = "VOLT"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="B"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="85",
             state="VALIDATED",
@@ -125,14 +106,11 @@ class AddPluginHybridVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Ford")
-        model = Model.objects.create(
-            name="FUSION ENERGI",
-            make=make
-        )
+        model = "FUSION ENERGI"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BX"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="42",
             state="VALIDATED",
@@ -140,14 +118,11 @@ class AddPluginHybridVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Honda")
-        model = Model.objects.create(
-            name="CLARITY PLUG-IN",
-            make=make
-        )
+        model = "CLARITY PLUG-IN"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BX"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="77",
             state="VALIDATED",
@@ -155,28 +130,22 @@ class AddPluginHybridVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Hyundai")
-        model = Model.objects.create(
-            name="IONIQ ELECTRIC PLUS",
-            make=make
-        )
+        model = "IONIQ ELECTRIC PLUS"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BX"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="47",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="M")
         )
 
-        model = Model.objects.create(
-            name="SONATA PLUG-IN",
-            make=make
-        )
+        model = "SONATA PLUG-IN"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BX"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="45",
             state="VALIDATED",
@@ -184,14 +153,11 @@ class AddPluginHybridVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Karma")
-        model = Model.objects.create(
-            name="REVERO",
-            make=make
-        )
+        model = "REVERO"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="B"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="60",
             state="VALIDATED",
@@ -199,28 +165,22 @@ class AddPluginHybridVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Kia")
-        model = Model.objects.create(
-            name="NIRO PLUG-IN",
-            make=make
-        )
+        model = "NIRO PLUG-IN"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BX"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="42",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="WS")
         )
 
-        model = Model.objects.create(
-            name="OPTIMA PLUG-IN",
-            make=make
-        )
+        model = "OPTIMA PLUG-IN"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BX"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="47",
             state="VALIDATED",
@@ -228,14 +188,11 @@ class AddPluginHybridVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Mercedes-Benz")
-        model = Model.objects.create(
-            name="GLC 350e 4MATIC",
-            make=make
-        )
+        model = "GLC 350e 4MATIC"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BZ"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="21",
             state="VALIDATED",
@@ -243,14 +200,11 @@ class AddPluginHybridVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Mini")
-        model = Model.objects.create(
-            name="COOPER S E COUNTRYMAN ALL4",
-            make=make
-        )
+        model = "COOPER S E COUNTRYMAN ALL4"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BZ"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="19",
             state="VALIDATED",
@@ -258,14 +212,11 @@ class AddPluginHybridVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Mitsubishi")
-        model = Model.objects.create(
-            name="OUTLANDER PHEV AWD",
-            make=make
-        )
+        model = "OUTLANDER PHEV AWD"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BX"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="35",
             state="VALIDATED",
@@ -273,42 +224,33 @@ class AddPluginHybridVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Porsche")
-        model = Model.objects.create(
-            name="CAYENNE E-HYBRID",
-            make=make
-        )
+        model = "CAYENNE E-HYBRID"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BZ"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="21",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="UL")
         )
 
-        model = Model.objects.create(
-            name="PANAMERA 4 E-HYBRID",
-            make=make
-        )
+        model = "PANAMERA 4 E-HYBRID"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="B"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="23",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="L")
         )
 
-        model = Model.objects.create(
-            name="PANAMERA TURBO S E-HYBRID",
-            make=make
-        )
+        model = "PANAMERA TURBO S E-HYBRID"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="B"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="23",
             state="VALIDATED",
@@ -316,14 +258,11 @@ class AddPluginHybridVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Toyota")
-        model = Model.objects.create(
-            name="PRIUS PRIME",
-            make=make
-        )
+        model = "PRIUS PRIME"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BX"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="40",
             state="VALIDATED",
@@ -331,42 +270,33 @@ class AddPluginHybridVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Volvo")
-        model = Model.objects.create(
-            name="S90 T8 AWD",
-            make=make
-        )
+        model = "S90 T8 AWD"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BZ"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="34",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="M")
         )
 
-        model = Model.objects.create(
-            name="XC60 T8 AWD",
-            make=make
-        )
+        model = "XC60 T8 AWD"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BZ"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="27",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="US")
         )
 
-        model = Model.objects.create(
-            name="XC90 T8 AWD",
-            make=make
-        )
+        model = "XC90 T8 AWD"
         Vehicle.objects.create(
             vehicle_fuel_type=FuelType.objects.get(vehicle_fuel_code="BZ"),
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="27",
             state="VALIDATED",

--- a/backend/api/fixtures/operational/0006_add_battery_electric_vehicles.py
+++ b/backend/api/fixtures/operational/0006_add_battery_electric_vehicles.py
@@ -27,14 +27,11 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         make = Make.objects.get(name="Audi")
         vehicle_fuel_type = FuelType.objects.get(vehicle_fuel_code="B")
 
-        model = Model.objects.create(
-            name="e-tron 55 QUATTRO",
-            make=make
-        )
+        model = "e-tron 55 QUATTRO"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="329",
             state="VALIDATED",
@@ -42,28 +39,22 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="BMW")
-        model = Model.objects.create(
-            name="i3 (120 Ah)",
-            make=make
-        )
+        model = "i3 (120 Ah)"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="246",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="S")
         )
 
-        model = Model.objects.create(
-            name="i3s (120 Ah)",
-            make=make
-        )
+        model = "i3s (120 Ah)"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="246",
             state="VALIDATED",
@@ -71,14 +62,11 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Chevrolet")
-        model = Model.objects.create(
-            name="BOLT EV",
-            make=make
-        )
+        model = "BOLT EV"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="383",
             state="VALIDATED",
@@ -86,27 +74,21 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Hyundai")
-        model = Model.objects.create(
-            name="IONIQ ELECTRIC",
-            make=make
-        )
+        model = "IONIQ ELECTRIC"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="200",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="M")
         )
-        model = Model.objects.create(
-            name="KONA ELECTRIC",
-            make=make
-        )
+        model = "KONA ELECTRIC"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="415",
             state="VALIDATED",
@@ -114,27 +96,21 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Kia")
-        model = Model.objects.create(
-            name="NIRO EV",
-            make=make
-        )
+        model = "NIRO EV"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="385",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="WS")
         )
-        model = Model.objects.create(
-            name="SOUL EV",
-            make=make
-        )
+        model = "SOUL EV"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="179",
             state="VALIDATED",
@@ -142,40 +118,31 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Nissan")
-        model = Model.objects.create(
-            name="LEAF (40 kWh)",
-            make=make
-        )
+        model = "LEAF (40 kWh)"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="243",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="M")
         )
-        model = Model.objects.create(
-            name="LEAF S PLUS",
-            make=make
-        )
+        model = "LEAF S PLUS"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="363",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="M")
         )
-        model = Model.objects.create(
-            name="LEAF SV/SL PLUS",
-            make=make
-        )
+        model = "LEAF SV/SL PLUS"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="349",
             state="VALIDATED",
@@ -183,27 +150,21 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Smart EQ")
-        model = Model.objects.create(
-            name="FORTWO CABRIOLET",
-            make=make
-        )
+        model = "FORTWO CABRIOLET"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="92",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="T")
         )
-        model = Model.objects.create(
-            name="FORTWO COUPE",
-            make=make
-        )
+        model = "FORTWO COUPE"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="93",
             state="VALIDATED",
@@ -211,144 +172,111 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Tesla")
-        model = Model.objects.create(
-            name="MODEL 3 Standard Range",
-            make=make
-        )
+        model = "MODEL 3 Standard Range"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="151",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="M")
         )
-        model = Model.objects.create(
-            name="MODEL 3 Standard Range Plus",
-            make=make
-        )
+        model = "MODEL 3 Standard Range Plus"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="386",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="M")
         )
-        model = Model.objects.create(
-            name="MODEL 3 Mid Range",
-            make=make
-        )
+        model = "MODEL 3 Mid Range"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="425",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="M")
         )
-        model = Model.objects.create(
-            name="MODEL 3 Long Range",
-            make=make
-        )
+        model = "MODEL 3 Long Range"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="499",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="M")
         )
-        model = Model.objects.create(
-            name="MODEL 3 Long Range AWD",
-            make=make
-        )
+        model = "MODEL 3 Long Range AWD"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="499",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="M")
         )
-        model = Model.objects.create(
-            name="MODEL 3 Long Range AWD Performance",
-            make=make
-        )
+        model = "MODEL 3 Long Range AWD Performance"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="499",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="M")
         )
-        model = Model.objects.create(
-            name="MODEL S 75D",
-            make=make
-        )
+        model = "MODEL S 75D"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="417",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="L")
         )
-        model = Model.objects.create(
-            name="MODEL S 100D",
-            make=make
-        )
+        model = "MODEL S 100D"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="539",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="L")
         )
-        model = Model.objects.create(
-            name="MODEL S P100D",
-            make=make
-        )
+        model = "MODEL S P100D"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="507",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="L")
         )
-        model = Model.objects.create(
-            name="MODEL S Standard Range",
-            make=make
-        )
+        model = "MODEL S Standard Range"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="459",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="L")
         )
-        model = Model.objects.create(
-            name="MODEL S Long Range",
-            make=make
-        )
+        model = "MODEL S Long Range"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="595",
             state="VALIDATED",
@@ -361,7 +289,7 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="555",
             state="VALIDATED",
@@ -374,72 +302,57 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="523",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="L")
         )
-        model = Model.objects.create(
-            name="MODEL X 75D",
-            make=make
-        )
+        model = "MODEL X 75D"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="383",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="UL")
         )
-        model = Model.objects.create(
-            name="MODEL X 100D",
-            make=make
-        )
+        model = "MODEL X 100D"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="475",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="UL")
         )
-        model = Model.objects.create(
-            name="MODEL X P100D",
-            make=make
-        )
+        model = "MODEL X P100D"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="465",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="UL")
         )
-        model = Model.objects.create(
-            name="MODEL X Standard Range",
-            make=make
-        )
+        model = "MODEL X Standard Range"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="410",
             state="VALIDATED",
             vehicle_class_code=VehicleClass.objects.get(vehicle_class_code="UL")
         )
-        model = Model.objects.create(
-            name="MODEL X Long Range",
-            make=make
-        )
+        model = "MODEL X Long Range"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="523",
             state="VALIDATED",
@@ -452,7 +365,7 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="491",
             state="VALIDATED",
@@ -465,7 +378,7 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="435",
             state="VALIDATED",
@@ -473,14 +386,11 @@ class AddBatteryElectricVehicles(OperationalDataScript):
         )
 
         make = Make.objects.get(name="Volkswagen")
-        model = Model.objects.create(
-            name="e-GOLF",
-            make=make
-        )
+        model = "e-GOLF"
         Vehicle.objects.create(
             vehicle_fuel_type=vehicle_fuel_type,
             make=make,
-            model=model,
+            model_name=model,
             model_year=model_year,
             range="201",
             state="VALIDATED",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,8 +14,9 @@ django-filter==2.2.0
 django-timezone-field==4.0
 djangorestframework==3.11.0
 djangorestframework-camel-case==1.1.2
-gunicorn>=19.7.0
+gunicorn==20.0.4
 idna==2.8
+importlib-metadata==1.5.0
 isort==4.3.21
 kombu==4.6.7
 lazy-object-proxy==1.4.3
@@ -30,6 +31,7 @@ pylint==2.4.4
 pylint-plugin-utils==0.2.6
 python-crontab==2.4.0
 python-dateutil==2.8.1
+python-dotenv==0.10.5
 pytz==2019.3
 requests==2.22.0
 six==1.13.0
@@ -39,3 +41,4 @@ urllib3==1.25.7
 vine==1.3.0
 virtualenv==16.0.0
 wrapt==1.11.2
+zipp==2.1.0

--- a/frontend/src/app/config.js
+++ b/frontend/src/app/config.js
@@ -1,9 +1,10 @@
-/* global __APIBASE__, __KEYCLOAK_URL__, __VERSION__ */
+/* global __APIBASE__, __KEYCLOAK_URL__, __VERSION__,
+ __KEYCLOAK_REALM_NAME__, __KEYCLOAK_CLIENT_ID__ */
 const CONFIG = {
   APIBASE: __APIBASE__, // injected by webpack
   KEYCLOAK: {
-    CLIENT_ID: 'zeva-app',
-    REALM: 'zeva',
+    CLIENT_ID: __KEYCLOAK_CLIENT_ID__,
+    REALM: __KEYCLOAK_REALM_NAME__,
     URL: __KEYCLOAK_URL__,
   },
   VERSION: __VERSION__,

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -103,6 +103,8 @@ const config = {
       __APIBASE__: 'APIBASE' in process.env ? JSON.stringify(process.env.APIBASE) : "'http://localhost/api/'",
       __KEYCLOAK_URL__: 'KEYCLOAK_URL' in process.env ? JSON.stringify(process.env.KEYCLOAK_URL) : "'http://localhost:8888/auth'",
       __VERSION__: JSON.stringify(packageJson.version),
+      __KEYCLOAK_REALM_NAME__: 'KEYCLOAK_REALM_NAME' in process.env ? JSON.stringify(process.env.KEYCLOAK_REALM_NAME) : "'zeva'",
+      __KEYCLOAK_CLIENT_ID__: 'KEYCLOAK_CLIENT_ID' in process.env ? JSON.stringify(process.env.KEYCLOAK_CLIENT_ID) : "'zeva-app'",
     }),
     new HtmlWebpackPlugin({
       title: 'ZEVA',

--- a/k8s-frontend.yaml
+++ b/k8s-frontend.yaml
@@ -47,6 +47,8 @@ spec:
               value: 'zeva-app'
             - name: KEYCLOAK_CLIENT_ID
               value: 'zeva-app'
+            - name: KEYCLOAK_REALM_NAME
+              value: 'zeva'
             - name: RABBITMQ_ENABLED
               value: 'False'
             - name: APIBASE


### PR DESCRIPTION
# Changelog
 - Frontend now loads `KEYCLOAK_CLIENT_ID` and `KEYCLOAK_REALM_NAME` environment vars
 - Backend fixtures adjusted to account for model changes
 - `requirements.txt` updated with missing `python-dotenv` requirement