### PR TITLE
increase test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ venv/
 
 db.sqlite3
 package-lock.json
+.coverage

--- a/backend/.coveragerc
+++ b/backend/.coveragerc
@@ -1,0 +1,19 @@
+[run]
+branch = True
+command_line = manage.py test -v 2
+source =
+    api/
+    zeva/
+    db_comments/
+    auditable/
+
+[report]
+exclude_lines =
+    pragma: no cover
+    raise AssertionError
+    raise NotImplementedError
+omit =
+    zeva/wsgi.py
+    api/management/*
+
+fail_under = 80

--- a/backend/api/management/dataloader.py
+++ b/backend/api/management/dataloader.py
@@ -3,8 +3,6 @@ import abc
 from django.db import transaction
 
 from api.management.data_script import OperationalDataScript
-from api.models.CompliancePeriod import CompliancePeriod
-
 
 class DataLoader(OperationalDataScript):
 

--- a/backend/api/tests/test_load_ops_data.py
+++ b/backend/api/tests/test_load_ops_data.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=no-member,invalid-name,duplicate-code
+import importlib
+import logging
+import sys
+from collections import namedtuple
+from unittest import mock
+
+import jwt
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from django.test import TestCase
+
+from api.management.commands._loader import ScriptLoader
+from api.management.dataloader import DataLoader
+from api.models.user_profile import UserProfile
+from api.tests.logging_client import LoggingClient
+
+from zeva import settings
+
+
+class TestLoadOpsData(TestCase):
+    """
+    Execute specified operational scripts to validate that they work
+    """
+
+    ScriptDefinition = namedtuple('ScriptDefinition', ('file', 'args', 'skip'), defaults=('', False,))
+
+    scripts = [
+        ScriptDefinition('api.fixtures.operational.0000_add_government_organization'),
+        ScriptDefinition('api.fixtures.operational.0001_add_vehicle_makes'),
+        ScriptDefinition('api.fixtures.operational.0002_add_vehicle_classes'),
+        ScriptDefinition('api.fixtures.operational.0003_add_vehicle_fuel_types'),
+        ScriptDefinition('api.fixtures.operational.0004_add_model_years'),
+        ScriptDefinition('api.fixtures.operational.0005_add_plugin_hybrid_vehicles'),
+        ScriptDefinition('api.fixtures.operational.0006_add_battery_electric_vehicles'),
+        ScriptDefinition('api.fixtures.operational.0007_add_organizations')
+    ]
+
+    logger = logging.getLogger('zeva.test')
+
+    def testOperationalScripts(self):
+        loader = ScriptLoader()
+
+        for script in self.scripts:
+            if not script.skip:
+                with self.subTest('testing operational script {file}'.format(file=script.file)):
+                    logging.debug('loading script: {file}'.format(file=script.file))
+                    loaded = importlib.import_module(script.file)
+                    instance = loaded.script_class(script.file, script.args)
+                    # (cls, source_code) = loader.load_from_file(script.file)
+                    # instance = cls(script.file, script.args)
+                    instance.check_run_preconditions()
+                    instance.run()

--- a/backend/api/tests/test_load_ops_data.py
+++ b/backend/api/tests/test_load_ops_data.py
@@ -2,23 +2,9 @@
 # pylint: disable=no-member,invalid-name,duplicate-code
 import importlib
 import logging
-import sys
 from collections import namedtuple
-from unittest import mock
 
-import jwt
-from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
 from django.test import TestCase
-
-from api.management.commands._loader import ScriptLoader
-from api.management.dataloader import DataLoader
-from api.models.user_profile import UserProfile
-from api.tests.logging_client import LoggingClient
-
-from zeva import settings
-
 
 class TestLoadOpsData(TestCase):
     """
@@ -41,15 +27,11 @@ class TestLoadOpsData(TestCase):
     logger = logging.getLogger('zeva.test')
 
     def testOperationalScripts(self):
-        loader = ScriptLoader()
-
         for script in self.scripts:
             if not script.skip:
                 with self.subTest('testing operational script {file}'.format(file=script.file)):
-                    logging.debug('loading script: {file}'.format(file=script.file))
+                    logging.info('loading script: {file}'.format(file=script.file))
                     loaded = importlib.import_module(script.file)
                     instance = loaded.script_class(script.file, script.args)
-                    # (cls, source_code) = loader.load_from_file(script.file)
-                    # instance = cls(script.file, script.args)
                     instance.check_run_preconditions()
                     instance.run()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ celery==4.4.0
 certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
+coverage==5.0.3
 cryptography==2.8
 Django==3.0.2
 django-celery-beat==1.5.0


### PR DESCRIPTION
#  Changelog
 - Add `coverage` python dependency to execute tests with coverage
 - Provide a sensible `.coveragerc` as a starting point
 - Include operational data scripts in testing, since a lot of the issues I've seen thus far locally have been with these scripts and their maintenance will be important.
 - Test coverage to 80%.

Execute tests with `coverage run` and see results with `coverage report`. `coverage report` will exit with nonzero status if coverage does not meet threshold of 80%. Recommend incorporating this command into the pipeline. The test pod must have a valid <strong>POSTGRES</strong> test database to run the tests.