### PR TITLE
Prebuild JS for Openshift

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zeva-grpc-frontend",
+  "name": "zeva-frontend",
   "version": "0.0.1",
   "private": true,
   "dependencies": {
@@ -14,12 +14,15 @@
     "amqp": "^0.2.7",
     "axios": "^0.19.1",
     "classnames": "^2.2.6",
+    "express": "^4.17.1",
+    "express-history-api-fallback": "^2.2.1",
     "history": "^4.10.1",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^1.6.0",
     "keycloak-js": "^8.0.1",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.27",
+    "morgan": "^1.9.1",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
@@ -70,7 +73,6 @@
     "webpack-subresource-integrity": "^1.3.4"
   },
   "scripts": {
-    "prepare": "eslint src",
     "start": "node start",
     "dist": "webpack --production",
     "test": "jest --coverage"

--- a/frontend/serve.js
+++ b/frontend/serve.js
@@ -1,0 +1,22 @@
+const http = require('http');
+const express = require('express');
+const fallback = require('express-history-api-fallback');
+const notifications = require('./notifications');
+const morgan = require('morgan');
+
+const websocketServer = http.createServer((req, res) => {
+  res.end();
+});
+
+const io = require('socket.io')(websocketServer);
+
+notifications.setup(io);
+websocketServer.listen(5002, '0.0.0.0');
+
+const app = express();
+app.use(morgan('combined'));
+
+const root = `${__dirname}/public/build`;
+app.use(express.static(root));
+app.use(fallback('generated_index.html', { root }));
+app.listen(5001);


### PR DESCRIPTION
# Changelog
 - Create a script to serve the app via `express` rather than `webpack-dev-server`
 - Disabled `eslint src` as `prepare` phase npm script. It blocks `npm install` from executing properly.

<strong>Devops notes</strong>:
 - Run `npm run dist` after `npm install` in build phase to generate script and resources
 - Use `node serve` as application entry point to launch service (launches on both port 5001 and 5002, as before).
 - Resolves `sockjs` connection issues, and builds in production mode
