### PR TITLE
Bugfix: Organization Edit Address

### DIFF
--- a/frontend/src/organizations/VehicleSupplierEditContainer.js
+++ b/frontend/src/organizations/VehicleSupplierEditContainer.js
@@ -59,29 +59,20 @@ const VehicleSupplierEditContainer = (props) => {
 
   const handleInputChange = (event) => {
     const { value, name } = event.target;
-    const address1 = details.organizationAddress ? details.organizationAddress.addressLine1 : '';
-    const address2 = details.organizationAddress ? details.organizationAddress.addressLine2 : '';
+
     setDetails({
       ...details,
       [name]: value,
-      organizationAddress: {
-        ...details.organizationAddress,
-        addressLine_1: address1,
-        addressLine_2: address2,
-      },
     });
   };
 
   const handleAddressChange = (event) => {
     const { value, name } = event.target;
-    const address1 = details.organizationAddress ? details.organizationAddress.addressLine1 : '';
-    const address2 = details.organizationAddress ? details.organizationAddress.addressLine2 : '';
+
     setDetails({
       ...details,
       organizationAddress: {
         ...details.organizationAddress,
-        addressLine_1: address1,
-        addressLine_2: address2,
         [name]: value,
       },
     });


### PR DESCRIPTION
Changelog:
- Fixed a bug where editing address line 2 undid the changes for address line 1 and vice versa.
(Since we're already populating AddressLine_1 and AddressLine_2 when we load the organization, we no longer need to maintain the values when we do HandleInputChange)