### PR TITLE
Removed python-magic-bin

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -39,8 +39,7 @@ pylint-plugin-utils==0.6
 python-crontab==2.4.0
 python-dateutil==2.8.1
 python-dotenv==0.10.5
-python-magic==0.4.15
-python-magic-bin==0.4.14
+python-magic==0.4.18
 pytz==2019.3
 requests==2.22.0
 six==1.13.0


### PR DESCRIPTION
Changelog:
- python-magic-bin is causing issues in openshift, so I'm just removing them as we're not using it directly