### PR TITLE
bug 3 back button filtering

### DIFF
--- a/frontend/src/vehicles/VehicleDetailsContainer.js
+++ b/frontend/src/vehicles/VehicleDetailsContainer.js
@@ -5,7 +5,8 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import { useParams } from 'react-router-dom';
-
+import { withRouter } from 'react-router';
+import PropTypes from 'prop-types';
 import history from '../app/History';
 import ROUTES_VEHICLES from '../app/routes/Vehicles';
 import CustomPropTypes from '../app/utilities/props';
@@ -17,7 +18,8 @@ const VehicleDetailsContainer = (props) => {
   const [comments, setComments] = useState({ vehicleComment: { comment: '' } });
   const { id } = useParams();
 
-  const { keycloak, user } = props;
+  const { keycloak, user, location } = props;
+  const { state: locationState } = location;
 
   const stateChange = (newState) => {
     setLoading(true);
@@ -47,6 +49,7 @@ const VehicleDetailsContainer = (props) => {
 
   return (
     <VehicleDetailsPage
+      locationState={locationState}
       comments={comments}
       details={vehicle}
       loading={loading}
@@ -61,6 +64,7 @@ const VehicleDetailsContainer = (props) => {
 VehicleDetailsContainer.propTypes = {
   keycloak: CustomPropTypes.keycloak.isRequired,
   user: CustomPropTypes.user.isRequired,
+  location: PropTypes.shape().isRequired,
 };
 
-export default VehicleDetailsContainer;
+export default withRouter(VehicleDetailsContainer);

--- a/frontend/src/vehicles/VehicleListContainer.js
+++ b/frontend/src/vehicles/VehicleListContainer.js
@@ -28,6 +28,9 @@ const VehicleListContainer = (props) => {
       queryFilter.push({ id: key, value });
     });
     setFiltered([...filtered, ...queryFilter]);
+    if (location.state) {
+      setFiltered([...filtered, ...location.state]);
+    }
     axios.get(ROUTES_VEHICLES.LIST).then((response) => {
       setVehicles(response.data);
       setLoading(false);

--- a/frontend/src/vehicles/components/VehicleDetailsPage.js
+++ b/frontend/src/vehicles/components/VehicleDetailsPage.js
@@ -21,6 +21,7 @@ const VehicleDetailsPage = (props) => {
     setComments,
     title,
     user,
+    locationState,
   } = props;
   const [requestChangeCheck, setRequestChangeCheck] = useState(false);
   const [showModal, setShowModal] = useState(false);
@@ -167,7 +168,7 @@ const VehicleDetailsPage = (props) => {
               <button
                 className="button"
                 onClick={() => {
-                  history.push(ROUTES_VEHICLES.LIST);
+                  history.push(ROUTES_VEHICLES.LIST, locationState);
                 }}
                 type="button"
               >
@@ -243,6 +244,7 @@ VehicleDetailsPage.defaultProps = {
   postComment: undefined,
   setComments: undefined,
   title: 'Vehicle Details',
+  locationState: undefined,
 };
 
 VehicleDetailsPage.propTypes = {
@@ -285,6 +287,7 @@ VehicleDetailsPage.propTypes = {
   setComments: PropTypes.func,
   title: PropTypes.string,
   user: CustomPropTypes.user.isRequired,
+  locationState: PropTypes.shape(),
 };
 
 export default VehicleDetailsPage;

--- a/frontend/src/vehicles/components/VehicleListTable.js
+++ b/frontend/src/vehicles/components/VehicleListTable.js
@@ -145,9 +145,9 @@ const VehicleListTable = (props) => {
               const { id, validationStatus } = row.original;
 
               if (['CHANGES_REQUESTED', 'DRAFT'].indexOf(validationStatus) >= 0 && !user.isGovernment) {
-                history.push(ROUTES_VEHICLES.EDIT.replace(/:id/g, id));
+                history.push(ROUTES_VEHICLES.EDIT.replace(/:id/g, id), filtered);
               } else {
-                history.push(ROUTES_VEHICLES.DETAILS.replace(/:id/g, id));
+                history.push(ROUTES_VEHICLES.DETAILS.replace(/:id/g, id), filtered);
               }
             },
             className: 'clickable',


### PR DESCRIPTION
added filtering when back button is clicked

"When you are in select ZEV model manufacturers, and then click on row to see details. You are brought to the details page which is nice. But then if you click 'baclk' to go back to your filtered search, you are instead brought back to the original list of all zev models. so you have to redefine your search criteria. Would be nice if when you select 'back' the zev model filter you applied sticks when you're switching from detailed view to filtered zev model view."