### PR TITLE
bug 21 - Validate / revalidate / recommend issuance buttons

### DIFF
--- a/frontend/src/credits/components/CreditRequestDetailsPage.js
+++ b/frontend/src/credits/components/CreditRequestDetailsPage.js
@@ -156,7 +156,7 @@ const CreditRequestDetailsPage = (props) => {
                 {validatedOnly
                     && (
                     <button
-                      className="button"
+                      className="button primary"
                       key="recommend-approval"
                       onClick={() => {
                         setModalType('approve');
@@ -168,7 +168,7 @@ const CreditRequestDetailsPage = (props) => {
                     </button>
                     )}
                 <button
-                  className="button primary"
+                  className="button"
                   onClick={() => {
                     const url = ROUTES_CREDITS.SALES_SUBMISSION_DETAILS.replace(/:id/g, submission.id);
 
@@ -176,7 +176,7 @@ const CreditRequestDetailsPage = (props) => {
                   }}
                   type="button"
                 >
-                  Validate
+                  Revalidate
                 </button>
               </span>
             </>

--- a/frontend/src/credits/components/CreditRequestDetailsPage.js
+++ b/frontend/src/credits/components/CreditRequestDetailsPage.js
@@ -153,6 +153,17 @@ const CreditRequestDetailsPage = (props) => {
                 <ButtonBack />
               </span>
               <span className="right-content">
+                <button
+                  className={validatedOnly ? 'button' : 'button primary'}
+                  onClick={() => {
+                    const url = ROUTES_CREDITS.SALES_SUBMISSION_DETAILS.replace(/:id/g, submission.id);
+
+                    history.push(url);
+                  }}
+                  type="button"
+                >
+                  {validatedOnly ? 'Re-validate' : 'Validate'}
+                </button>
                 {validatedOnly
                     && (
                     <button
@@ -167,17 +178,7 @@ const CreditRequestDetailsPage = (props) => {
                       Recommend Issuance
                     </button>
                     )}
-                <button
-                  className="button"
-                  onClick={() => {
-                    const url = ROUTES_CREDITS.SALES_SUBMISSION_DETAILS.replace(/:id/g, submission.id);
 
-                    history.push(url);
-                  }}
-                  type="button"
-                >
-                  Revalidate
-                </button>
               </span>
             </>
             )}


### PR DESCRIPTION
after a sale has been validated, the validate button will reappear on the page with a comment box and "recommend issuance" button--swapped order of these buttons and made the recommend issuance primary, changed button to "re-validate"
