### PR TITLE
ZEVA 318 - edit credit transfer draft

### DIFF
--- a/frontend/src/app/css/Form.scss
+++ b/frontend/src/app/css/Form.scss
@@ -115,7 +115,7 @@
     padding-left: 1.25rem;
   }
   .currency-symbol {
-    z-index:9999;
+    z-index:100;
     position: absolute;
     top: 0;
     bottom: 0;

--- a/frontend/src/app/router.js
+++ b/frontend/src/app/router.js
@@ -15,7 +15,7 @@ import VehicleSupplierUserListContainer from '../organizations/VehicleSupplierUs
 import RoleListContainer from '../roles/RoleListContainer';
 import CreditsContainer from '../credits/CreditsContainer';
 import CreditRequestListContainer from '../credits/CreditRequestListContainer';
-import CreditTransfersContainer from '../credits/CreditTransfersContainer';
+import CreditTransfersEditContainer from '../credits/CreditTransfersEditContainer';
 import CreditTransferListContainer from '../credits/CreditTransferListContainer';
 import CreditRequestDetailsContainer from '../credits/CreditRequestDetailsContainer';
 import CreditTransfersDetailsContainer from '../credits/CreditTransfersDetailsContainer';
@@ -215,7 +215,12 @@ class Router extends Component {
               <Route
                 exact
                 path={ROUTES_CREDIT_TRANSFERS.NEW}
-                render={() => <CreditTransfersContainer keycloak={keycloak} user={user} />}
+                render={() => <CreditTransfersEditContainer keycloak={keycloak} user={user} newTransfer/>}
+              />
+              <Route
+                exact
+                path={ROUTES_CREDIT_TRANSFERS.EDIT}
+                render={() => <CreditTransfersEditContainer keycloak={keycloak} user={user} />}
               />
               <Route
                 path={ROUTES_CREDIT_TRANSFERS.DETAILS}

--- a/frontend/src/app/routes/CreditTransfers.js
+++ b/frontend/src/app/routes/CreditTransfers.js
@@ -4,6 +4,7 @@ const CREDIT_REQUESTS = {
   NEW: `${API_BASE_PATH}/new`,
   LIST: API_BASE_PATH,
   DETAILS: `${API_BASE_PATH}/:id`,
+  EDIT:  `${API_BASE_PATH}/:id/edit`,
 };
 
 export default CREDIT_REQUESTS;

--- a/frontend/src/credits/CreditTransfersEditContainer.js
+++ b/frontend/src/credits/CreditTransfersEditContainer.js
@@ -4,15 +4,18 @@
  */
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import history from '../app/History';
 import CreditTransactionTabs from '../app/components/CreditTransactionTabs';
 import CustomPropTypes from '../app/utilities/props';
-import CreditTransfersPage from './components/CreditTransfersPage';
+import CreditTransfersForm from './components/CreditTransfersForm';
 import ROUTES_ORGANIZATIONS from '../app/routes/Organizations';
 import ROUTES_CREDIT_TRANSFERS from '../app/routes/CreditTransfers';
 import ROUTES_VEHICLES from '../app/routes/Vehicles';
 
-const CreditTransfersContainer = (props) => {
+const CreditTransfersEditContainer = (props) => {
+  const { id } = useParams();
   const emptyCheckboxes = {
     authority: false, accurate: false, consent: false,
   };
@@ -24,15 +27,15 @@ const CreditTransfersContainer = (props) => {
   };
   const [checkboxes, setCheckboxes] = useState(emptyCheckboxes);
   const [rows, setRows] = useState([emptyRow]);
-  const { user, keycloak } = props;
+  const { user, keycloak, newTransfer } = props;
   const [organizations, setOrganizations] = useState([]);
   const [fields, setFields] = useState(emptyForm);
   const [years, setYears] = useState([]);
   const [unfilledRow, setUnfilledRow] = useState(true);
   const checkboxText = 'Please complete all fields in the transfer.';
   const [hoverText, setHoverText] = useState(checkboxText);
-
-  const checkFilled = (input) => {
+  const [loading, setLoading] = useState(true);
+  const checkFilled = (input, partner=fields) => {
     Object.entries(input).forEach(([key, val]) => {
       if (
         val.creditType === ''
@@ -79,6 +82,7 @@ const CreditTransfersContainer = (props) => {
   const submitOrSave = (status) => {
     const creditTo = fields.transferPartner;
     const debitFrom = user.organization.id;
+
     const data = rows
       .filter((row) => row.quantity && row.value && row.creditType && row.modelYear)
       .map((row) => ({
@@ -91,14 +95,25 @@ const CreditTransfersContainer = (props) => {
         transactionType: 'Credit Transfer',
         weightClass: 'LDV',
       }));
-    axios.post(ROUTES_CREDIT_TRANSFERS.LIST, {
-      content: data,
-      status,
-      creditTo,
-      debitFrom,
-    }).then(() => {
-      history.push(ROUTES_CREDIT_TRANSFERS.LIST);
-    });
+    if (newTransfer) {
+      axios.post(ROUTES_CREDIT_TRANSFERS.LIST, {
+        content: data,
+        status,
+        creditTo,
+        debitFrom,
+      }).then(() => {
+        history.push(ROUTES_CREDIT_TRANSFERS.LIST);
+      });
+    } else {
+      axios.patch(ROUTES_CREDIT_TRANSFERS.DETAILS.replace(/:id/gi, id), {
+        content: data,
+        status,
+        creditTo,
+        debitFrom,
+      }).then((response) => {
+        history.push(ROUTES_CREDIT_TRANSFERS.LIST);
+      });
+    }
   };
   const handleSave = () => {
     submitOrSave('DRAFT');
@@ -108,6 +123,7 @@ const CreditTransfersContainer = (props) => {
   };
 
   const refreshDetails = () => {
+    setLoading(true);
     axios.all([
       axios.get(ROUTES_ORGANIZATIONS.LIST),
       axios.get(ROUTES_VEHICLES.YEARS),
@@ -115,6 +131,22 @@ const CreditTransfersContainer = (props) => {
       setOrganizations(orgResponse.data);
       setYears(yearsResponse.data);
     }));
+    if (!newTransfer) {
+      axios.get(ROUTES_CREDIT_TRANSFERS.DETAILS.replace(/:id/gi, id)).then((response) => {
+        const details = response.data;
+        setFields({ ...fields, transferPartner: details.creditTo.id });
+        const rowInfo = details.creditTransferContent.map((each) => ({
+          creditType: each.creditClass.creditClass,
+          modelYear: each.modelYear.name,
+          quantity: each.creditValue,
+          value: each.dollarValue,
+        }));
+        setRows(rowInfo);
+        setUnfilledRow(false);
+        setHoverText('');
+      });
+    }
+    setLoading(false);
   };
 
   useEffect(() => {
@@ -124,7 +156,8 @@ const CreditTransfersContainer = (props) => {
   const total = rows.reduce((a, v) => a + v.quantity * v.value, 0);
   return ([
     <CreditTransactionTabs active="credit-transfers" key="tabs" user={user} />,
-    <CreditTransfersPage
+    <CreditTransfersForm
+      loading={loading}
       key="page"
       user={user}
       organizations={organizations}
@@ -146,8 +179,13 @@ const CreditTransfersContainer = (props) => {
   ]);
 };
 
-CreditTransfersContainer.propTypes = {
-  user: CustomPropTypes.user.isRequired,
+CreditTransfersEditContainer.defaultProps = {
+  newTransfer: false,
 };
 
-export default CreditTransfersContainer;
+CreditTransfersEditContainer.propTypes = {
+  user: CustomPropTypes.user.isRequired,
+  newTransfer: PropTypes.bool,
+};
+
+export default CreditTransfersEditContainer;

--- a/frontend/src/credits/components/CreditTransfersForm.js
+++ b/frontend/src/credits/components/CreditTransfersForm.js
@@ -8,25 +8,26 @@ import CustomPropTypes from '../../app/utilities/props';
 import TransferFormRow from './TransferFormRow';
 import FormDropdown from './FormDropdown';
 import CreditTransferSignoff from './CreditTransfersSignOff';
+import Loading from '../../app/components/Loading';
 
-const CreditTransfersPage = (props) => {
+const CreditTransfersForm = (props) => {
   const {
-    user,
-    organizations,
-    handleInputChange,
-    handleSubmit,
-    years,
-    handleSave,
-    removeRow,
     addRow,
-    handleRowInputChange,
-    total,
-    rows,
-    fields,
-    unfilledRow,
     checkboxes,
-    setCheckboxes,
+    fields,
+    handleInputChange,
+    handleRowInputChange,
+    handleSave,
+    handleSubmit,
     hoverText,
+    organizations,
+    removeRow,
+    rows,
+    setCheckboxes,
+    total,
+    unfilledRow,
+    user,
+    years,
   } = props;
   const [showModal, setShowModal] = useState(false);
   const submitTooltip = 'You must acknowledge the three confirmation checkboxes prior to submitting this transfer.';
@@ -61,6 +62,7 @@ const CreditTransfersPage = (props) => {
           </span>
           <span className="right-content">
             <Button
+              disabled={unfilledRow || fields.transferPartner === ''}
               buttonType="save"
               action={() => {
                 handleSave();
@@ -128,13 +130,13 @@ const CreditTransfersPage = (props) => {
   );
 };
 
-CreditTransfersPage.defaultProps = {
+CreditTransfersForm.defaultProps = {
   checkboxes: { authority: false, accurate: false, consent: false },
   unfilledRow: true,
   hoverText: '',
 };
 
-CreditTransfersPage.propTypes = {
+CreditTransfersForm.propTypes = {
   user: CustomPropTypes.user.isRequired,
   organizations: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   handleInputChange: PropTypes.func.isRequired,
@@ -153,4 +155,4 @@ CreditTransfersPage.propTypes = {
   hoverText: PropTypes.string,
 };
 
-export default CreditTransfersPage;
+export default CreditTransfersForm;

--- a/frontend/src/credits/components/CreditTransfersListTable.js
+++ b/frontend/src/credits/components/CreditTransfersListTable.js
@@ -23,11 +23,10 @@ const CreditTransfersListTable = (props) => {
     if (item.creditTransferContent) {
       item.creditTransferContent.forEach((row) => {
         if (row.creditClass.creditClass === 'A') {
-          totalCreditsA += row.creditValue;
+          totalCreditsA += parseFloat(row.creditValue);
         }
-
         if (row.creditClass.creditClass === 'B') {
-          totalCreditsB += row.creditValue;
+          totalCreditsB += parseFloat(row.creditValue);
         }
 
         totalTransferValue += (parseFloat(row.dollarValue) * row.creditValue);
@@ -69,13 +68,13 @@ const CreditTransfersListTable = (props) => {
     Header: 'Transfer Partner',
     id: 'partner',
   }, {
-    accessor: (row) => (row.totalCreditsA > 0 ? formatNumeric(row.totalCreditsA) : '-'),
+    accessor: (row) => (row.totalCreditsA !== 0 ? formatNumeric(row.totalCreditsA) : '-'),
     className: 'text-right',
     Header: 'A-Credits',
     id: 'credits-a',
     maxWidth: 150,
   }, {
-    accessor: (row) => (row.totalCreditsB > 0 ? formatNumeric(row.totalCreditsB) : '-'),
+    accessor: (row) => (row.totalCreditsB !== 0 ? formatNumeric(row.totalCreditsB) : '-'),
     className: 'text-right',
     Header: 'B-Credits',
     id: 'credits-b',
@@ -135,8 +134,12 @@ const CreditTransfersListTable = (props) => {
         if (row && row.original) {
           return {
             onClick: () => {
-              const { id } = row.original;
-              history.push(ROUTES_CREDIT_TRANSFERS.DETAILS.replace(/:id/g, id), filtered);
+              const { id, status } = row.original;
+              if (status === 'DRAFT') {
+                history.push(ROUTES_CREDIT_TRANSFERS.EDIT.replace(/:id/g, id));
+              } else {
+                history.push(ROUTES_CREDIT_TRANSFERS.DETAILS.replace(/:id/g, id), filtered);
+              }
             },
             className: 'clickable',
           };


### PR DESCRIPTION
-added edit ability by loading new form with prefilled values when draft record is clicked
-added serializer for updating transfer content and partner
-changed transfer container and page to be editContainer and form to match other components
-added check for partner and filled rows before saving
