### PR TITLE
ZEVA-311: Make Validation for IDIR Users

### DIFF
--- a/backend/api/models/sales_submission_content.py
+++ b/backend/api/models/sales_submission_content.py
@@ -161,7 +161,11 @@ class SalesSubmissionContent(Auditable):
         elif self.vehicle is not None:
             if self.icbc_verification.icbc_vehicle.model_year != \
                     self.vehicle.model_year:
-                warnings.append('MODEL_MISMATCHED')
+                warnings.append('MODEL_YEAR_MISMATCHED')
+
+            if self.icbc_verification.icbc_vehicle.make != \
+                    self.vehicle.make:
+                warnings.append('MAKE_MISMATCHED')
 
         return warnings
 

--- a/backend/api/services/sales_spreadsheet.py
+++ b/backend/api/services/sales_spreadsheet.py
@@ -463,8 +463,11 @@ def create_errors_spreadsheet(submission_id, organization_id, stream):
         if 'INVALID_MODEL' in content.warnings:
             error += 'invalid make, model and year combination; '
 
-        if 'MODEL_MISMATCHED' in content.warnings:
+        if 'MODEL_YEAR_MISMATCHED' in content.warnings:
             error += 'Model year does not match BC registration data; '
+
+        if 'MAKE_MISMATCHED' in content.warnings:
+            error += 'Make does not match BC registration data; '
 
         if 'NO_ICBC_MATCH' in content.warnings:
             error += 'VIN not registered in BC; '

--- a/frontend/src/app/constants/errorCodes.js
+++ b/frontend/src/app/constants/errorCodes.js
@@ -1,4 +1,4 @@
-export const CREDIT_ERROR_CODES = {
+const CREDIT_ERROR_CODES = {
   DUPLICATE_VIN: {
     errorCode: 31,
     errorField: 'vin',
@@ -9,15 +9,19 @@ export const CREDIT_ERROR_CODES = {
   },
   INVALID_DATE: {
     errorCode: 61,
-    errorField: 'sales-date'
+    errorField: 'sales-date',
   },
   INVALID_MODEL: {
     errorCode: 71,
     errorField: 'model-year make model',
   },
-  MODEL_MISMATCHED: {
+  MODEL_YEAR_MISMATCHED: {
     errorCode: 41,
-    errorField: 'icbc-model-year icbc-make icbc-model'
+    errorField: 'icbc-model-year',
+  },
+  MAKE_MISMATCHED: {
+    errorCode: 41,
+    errorField: 'icbc-make',
   },
   NO_ICBC_MATCH: {
     errorCode: 11,
@@ -32,3 +36,5 @@ export const CREDIT_ERROR_CODES = {
     errorField: 'vin',
   },
 };
+
+export default CREDIT_ERROR_CODES;

--- a/frontend/src/app/css/ReactTable.scss
+++ b/frontend/src/app/css/ReactTable.scss
@@ -4,8 +4,26 @@
   }
 
   .icbc-warning {
-    .icbc-model-year, .icbc-make, .icbc-model, .warning, .validated {
+    .warning, .validated {
       background-color: $background-warning !important;
+    }
+
+    &.warning-icbc-make .icbc-make {
+      background-color: $background-warning !important;
+    }
+
+    &.warning-icbc-model-year .icbc-model-year {
+      background-color: $background-warning !important;
+    }
+
+    &.warning-sales-date .sales-date {
+      background-color: $background-warning !important;
+    }
+
+    &.warning-vin {
+      .icbc-make, .icbc-model, .icbc-model-year, .vin {
+        background-color: $background-warning !important;
+      }
     }
   }
 

--- a/frontend/src/credits/components/CreditRequestVINListPage.js
+++ b/frontend/src/credits/components/CreditRequestVINListPage.js
@@ -59,7 +59,7 @@ const CreditRequestVINListPage = (props) => {
           11 = VIN not registered in BC;{' '}
           21 = VIN already issued credit;{' '}
           31 = Duplicate VIN;{' '}
-          41 = Model year does not match BC registration data;{' '}
+          41 = Model year and/or Make does not match BC registration data;{' '}
           51 = Sale prior to 2 Jan 2018;{' '}
           61 = Invalid Date Format
         </div>

--- a/frontend/src/credits/components/VINListTable.js
+++ b/frontend/src/credits/components/VINListTable.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import ReactTable from '../../app/components/ReactTable';
-import { CREDIT_ERROR_CODES } from '../../app/constants/errorCodes';
+import CREDIT_ERROR_CODES from '../../app/constants/errorCodes';
 import CustomPropTypes from '../../app/utilities/props';
 
 const VINListTable = (props) => {
@@ -68,7 +68,7 @@ const VINListTable = (props) => {
       id: 'model',
     }, {
       accessor: (row) => (moment(row.salesDate).format('YYYY-MM-DD') !== 'Invalid date' ? moment(row.salesDate).format('YYYY-MM-DD') : row.salesDate),
-      className: 'text-center',
+      className: 'text-center sales-date',
       Header: 'Retail Sale',
       id: 'sales-date',
     }],
@@ -161,8 +161,26 @@ const VINListTable = (props) => {
           }
 
           if (warnings.some((each) => ['11', '41', '61'].includes(each))) {
+            let className = 'icbc-warning';
+
+            if (rowInfo.original.warnings.includes('INVALID_DATE')) {
+              className += ' warning-sales-date';
+            }
+
+            if (rowInfo.original.warnings.includes('MAKE_MISMATCHED')) {
+              className += ' warning-icbc-make';
+            }
+
+            if (rowInfo.original.warnings.includes('MODEL_YEAR_MISMATCHED')) {
+              className += ' warning-icbc-model-year';
+            }
+
+            if (rowInfo.original.warnings.includes('NO_ICBC_MATCH')) {
+              className += ' warning-vin';
+            }
+
             return {
-              className: 'icbc-warning',
+              className,
             };
           }
         }

--- a/frontend/src/credits/components/VINListTable.js
+++ b/frontend/src/credits/components/VINListTable.js
@@ -30,7 +30,7 @@ const VINListTable = (props) => {
       if (CREDIT_ERROR_CODES[warning]) {
         if (fields) {
           errorCodes += ` ${CREDIT_ERROR_CODES[warning].errorField} `;
-        } else {
+        } else if (!errorCodes.includes(CREDIT_ERROR_CODES[warning].errorCode)) {
           if (errorCodes !== '' && CREDIT_ERROR_CODES[warning].errorCode) {
             errorCodes += ', ';
           }


### PR DESCRIPTION
Changelog:
- Make is now being validated when an analyst reviews a credit application
- Warning background only highlights either model year or make when receiving a 41 warning
- Added warning background on the VIN if there's no matching icbc match
- Added warning background on sales date if the format is invalid