### PR TITLE
ZEVA-341: Credit Transfers should not show up if it's not enabled

### DIFF
--- a/frontend/src/app/router.js
+++ b/frontend/src/app/router.js
@@ -37,7 +37,6 @@ import ROUTES_CREDIT_REQUESTS from './routes/CreditRequests';
 import ROUTES_CREDIT_TRANSFERS from './routes/CreditTransfers';
 import ROUTES_CREDITS from './routes/Credits';
 import ROUTES_ORGANIZATIONS from './routes/Organizations';
-import ROUTES_ROLES from './routes/Roles';
 import ROUTES_USERS from './routes/Users';
 import ROUTES_VEHICLES from './routes/Vehicles';
 
@@ -200,28 +199,33 @@ class Router extends Component {
                 path={ROUTES_CREDITS.UPLOAD_VERIFICATION}
                 render={() => <UploadICBCVerificationContainer keycloak={keycloak} user={user} />}
               />
-
-              <Route
-                exact
-                path={ROUTES_CREDIT_TRANSFERS.LIST}
-                render={() => <CreditTransferListContainer keycloak={keycloak} user={user} />}
-              />
-              <Route
-                exact
-                path={ROUTES_CREDIT_TRANSFERS.NEW}
-                render={() => <CreditTransfersEditContainer keycloak={keycloak} user={user} newTransfer/>}
-              />
-              <Route
-                exact
-                path={ROUTES_CREDIT_TRANSFERS.EDIT}
-                render={() => <CreditTransfersEditContainer keycloak={keycloak} user={user} />}
-              />
-              <Route
-                path={ROUTES_CREDIT_TRANSFERS.DETAILS}
-                render={() => (
-                  <CreditTransfersDetailsContainer keycloak={keycloak} user={user} />
-                )}
-              />
+              {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED && ([
+                <Route
+                  exact
+                  key="route-credit-transfers-list"
+                  path={ROUTES_CREDIT_TRANSFERS.LIST}
+                  render={() => <CreditTransferListContainer keycloak={keycloak} user={user} />}
+                />,
+                <Route
+                  exact
+                  key="route-credit-transfers-new"
+                  path={ROUTES_CREDIT_TRANSFERS.NEW}
+                  render={() => <CreditTransfersEditContainer keycloak={keycloak} user={user} newTransfer/>}
+                />,
+                <Route
+                  exact
+                  key="route-credit-transfers-edit"
+                  path={ROUTES_CREDIT_TRANSFERS.EDIT}
+                  render={() => <CreditTransfersEditContainer keycloak={keycloak} user={user} />}
+                />,
+                <Route
+                  key="route-credit-transfers-details"
+                  path={ROUTES_CREDIT_TRANSFERS.DETAILS}
+                  render={() => (
+                    <CreditTransfersDetailsContainer keycloak={keycloak} user={user} />
+                  )}
+                />,
+              ])}
               <Route
                 exact
                 path={ROUTES_CREDIT_REQUESTS.NEW}

--- a/frontend/src/dashboard/DashboardContainer.js
+++ b/frontend/src/dashboard/DashboardContainer.js
@@ -61,7 +61,7 @@ const DashboardContainer = (props) => {
       .filter((submission) => submission.status === 'APPROVED' || submission.status === 'RECOMMEND_APPROVAL');
     const transfersRecorded = transfersResponse.data
       .filter((submission) => submission.status === 'VALIDATED');
-      const transfersRejected = transfersResponse.data
+    const transfersRejected = transfersResponse.data
       .filter((submission) => submission.status === 'REJECTED');
     setActivityCount({
       ...activityCount,
@@ -90,7 +90,7 @@ const DashboardContainer = (props) => {
       .filter((submission) => submission.validationStatus === 'RECOMMEND_REJECTION');
     const analystNeeded = salesResponse.data
       .filter((submission) => ['SUBMITTED', 'CHECKED'].indexOf(submission.validationStatus) >= 0);
-    const transfersAwaitingPartner= transfersResponse.data
+    const transfersAwaitingPartner = transfersResponse.data
       .filter((submission) => submission.status === 'SUBMITTED');
     const transfersAwaitingDirector = transfersResponse.data
       .filter((submission) => submission.status === 'RECOMMEND_APPROVAL' || submission.status === 'RECOMMENDED_REJECTION' || submission.status === 'APPROVED');

--- a/frontend/src/dashboard/components/ActionsBceid.js
+++ b/frontend/src/dashboard/components/ActionsBceid.js
@@ -6,6 +6,7 @@ import ActivityBanner from './ActivityBanner';
 import ROUTES_VEHICLES from '../../app/routes/Vehicles';
 import ROUTES_CREDIT_REQUESTS from '../../app/routes/CreditRequests';
 import ROUTES_CREDIT_TRANSFERS from '../../app/routes/CreditTransfers';
+import CONFIG from '../../app/config';
 
 const ActionsBceid = (props) => {
   const { activityCount, loading } = props;
@@ -119,7 +120,8 @@ const ActionsBceid = (props) => {
             linkTo={ROUTES_CREDIT_REQUESTS.LIST}
           />
         )}
-        {activityCount.transfersAwaitingPartner > 0
+        {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED
+        && activityCount.transfersAwaitingPartner > 0
         && (
         <ActivityBanner
           colour="yellow"
@@ -129,7 +131,8 @@ const ActionsBceid = (props) => {
           linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Submitted`}
         />
         )}
-        {activityCount.transfersAwaitingGovernment > 0
+        {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED
+        && activityCount.transfersAwaitingGovernment > 0
         && (
         <ActivityBanner
           colour="blue"
@@ -139,7 +142,8 @@ const ActionsBceid = (props) => {
           linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Approved`}
         />
         )}
-        {activityCount.transfersRecorded > 0
+        {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED
+        && activityCount.transfersRecorded > 0
         && (
         <ActivityBanner
           colour="green"
@@ -149,7 +153,8 @@ const ActionsBceid = (props) => {
           linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Issued`}
         />
         )}
-        {activityCount.transfersAwaitingGovernment === 0
+        {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED
+        && activityCount.transfersAwaitingGovernment === 0
         && activityCount.transfersAwaitingPartner === 0 && activityCount.transfersRecorded === 0
         && (
           <ActivityBanner
@@ -160,7 +165,8 @@ const ActionsBceid = (props) => {
             linkTo={ROUTES_CREDIT_TRANSFERS.LIST}
           />
         )}
-        {activityCount.transfersRejected > 0
+        {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED
+        && activityCount.transfersRejected > 0
         && (
         <ActivityBanner
           colour="red"

--- a/frontend/src/dashboard/components/ActionsIdir.js
+++ b/frontend/src/dashboard/components/ActionsIdir.js
@@ -8,6 +8,8 @@ import Loading from '../../app/components/Loading';
 import CustomPropTypes from '../../app/utilities/props';
 import ActivityBanner from './ActivityBanner';
 
+import CONFIG from '../../app/config';
+
 const ActionsIdir = (props) => {
   const { user, activityCount, loading } = props;
   if (loading) {
@@ -79,7 +81,9 @@ const ActionsIdir = (props) => {
             linkTo={ROUTES_CREDIT_REQUESTS.LIST}
           />
         )}
-        {activityCount.transfersAwaitingPartner > 0 && user.hasPermission('RECOMMEND_SALES')
+        {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED
+        && activityCount.transfersAwaitingPartner > 0
+        && user.hasPermission('RECOMMEND_SALES')
         && (
         <ActivityBanner
           colour="yellow"
@@ -89,7 +93,8 @@ const ActionsIdir = (props) => {
           linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Submitted`}
         />
         )}
-        {activityCount.transfersAwaitingDirector > 0
+        {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED
+        && activityCount.transfersAwaitingDirector > 0
         && (
         <ActivityBanner
           colour="blue"
@@ -99,7 +104,8 @@ const ActionsIdir = (props) => {
           linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Approved`}
         />
         )}
-        {activityCount.transfersAwaitingDirector === 0 && activityCount.transfersAwaitingAnalyst === 0
+        {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED
+        && activityCount.transfersAwaitingDirector === 0 && activityCount.transfersAwaitingAnalyst === 0
         && activityCount.transfersAwaitingPartner === 0 && activityCount.transfersRecorded === 0
         && (
           <ActivityBanner


### PR DESCRIPTION
Changelog:
- Dashboard alerts should no longer show credit transfers, unless enabled
- Routes to Credit transfers should now be disabled, unless enabled in the config