### PR TITLE
ZEVA-373: Fixed Credit Transaction showing incorrect order

### DIFF
--- a/frontend/src/credits/components/CreditTransactions.js
+++ b/frontend/src/credits/components/CreditTransactions.js
@@ -11,6 +11,18 @@ const CreditTransactions = (props) => {
 
   const transactions = [];
 
+  items.sort((a, b) => {
+    if (a.transactionTimestamp < b.transactionTimestamp) {
+      return -1;
+    }
+
+    if (a.transactionTimestamp > b.transactionTimestamp) {
+      return 1;
+    }
+
+    return 0;
+  });
+
   items.forEach((item) => {
     if (item.creditClass.creditClass === 'A') {
       totalA += parseFloat(item.totalValue);


### PR DESCRIPTION
Changelog:
- Fixed ordering of items for the Credit Transactions
- Automatically create a kink between credit transfer and credit transaction when a transfer is recorded