### PR TITLE
Thursday Jan 8 Transfer bugs and changes

### DIFF
--- a/backend/api/viewsets/credit_transfer.py
+++ b/backend/api/viewsets/credit_transfer.py
@@ -47,6 +47,7 @@ class CreditTransferViewset(
                 CreditTransferStatuses.SUBMITTED,
                 CreditTransferStatuses.DELETED,
                 CreditTransferStatuses.RESCIND_PRE_APPROVAL,
+                CreditTransferStatuses.DISAPPROVED,
             ])
         else:
             queryset = CreditTransfer.objects.filter(

--- a/frontend/src/app/components/Button.js
+++ b/frontend/src/app/components/Button.js
@@ -128,7 +128,7 @@ Button.defaultProps = {
 Button.propTypes = {
   buttonType: PropTypes.string.isRequired,
   locationRoute: PropTypes.string,
-  locationState: PropTypes.arrayOf(PropTypes.shape()),
+  locationState: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.shape()), PropTypes.shape()]),
   optionalText: PropTypes.string,
   optionalIcon: PropTypes.string,
   optionalClassname: PropTypes.string,

--- a/frontend/src/credits/CreditTransfersEditContainer.js
+++ b/frontend/src/credits/CreditTransfersEditContainer.js
@@ -38,7 +38,7 @@ const CreditTransfersEditContainer = (props) => {
   const checkboxText = 'Please complete all fields in the transfer.';
   const [hoverText, setHoverText] = useState(checkboxText);
   const [loading, setLoading] = useState(true);
-  const checkFilled = (input, partner=fields) => {
+  const checkFilled = (input, partner = fields) => {
     Object.entries(input).forEach(([key, val]) => {
       if (
         val.creditType === ''
@@ -70,6 +70,21 @@ const CreditTransfersEditContainer = (props) => {
     const { value, name } = event.target;
     const rowsCopy = JSON.parse(JSON.stringify(rows));
     rowsCopy[rowId][name] = value;
+    if (name === 'value') {
+      const hasDecimal = value.indexOf('.') >= 0;
+      if (hasDecimal) {
+        const numberOfDecimals = value.split('.')[1].length;
+        if (numberOfDecimals > 2) {
+          rowsCopy[rowId][name] = parseFloat(value).toFixed(2);
+        }
+      }
+    }
+    if (name === 'quantity') {
+      const hasDecimal = value.indexOf('.') >= 0;
+      if (hasDecimal) {
+        rowsCopy[rowId][name] = parseFloat(value).toFixed(0);
+      }
+    }
     setRows(rowsCopy);
     checkFilled(rowsCopy);
   };
@@ -114,7 +129,6 @@ const CreditTransfersEditContainer = (props) => {
         .catch((error) => {
           const { response } = error;
           if (response.status === 400) {
-            console.log(response)
             setErrorMessage(error.response.data.status);
           }
         });

--- a/frontend/src/credits/CreditTransfersEditContainer.js
+++ b/frontend/src/credits/CreditTransfersEditContainer.js
@@ -114,6 +114,7 @@ const CreditTransfersEditContainer = (props) => {
         .catch((error) => {
           const { response } = error;
           if (response.status === 400) {
+            console.log(response)
             setErrorMessage(error.response.data.status);
           }
         });

--- a/frontend/src/credits/components/CreditRequestDetailsPage.js
+++ b/frontend/src/credits/components/CreditRequestDetailsPage.js
@@ -347,7 +347,7 @@ CreditRequestDetailsPage.defaultProps = {
 
 CreditRequestDetailsPage.propTypes = {
   handleSubmit: PropTypes.func.isRequired,
-  locationState: PropTypes.arrayOf(PropTypes.shape()),
+  locationState: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.shape()), PropTypes.shape()]),
   submission: PropTypes.shape().isRequired,
   uploadDate: PropTypes.string.isRequired,
   user: CustomPropTypes.user.isRequired,

--- a/frontend/src/credits/components/CreditTransactionListTable.js
+++ b/frontend/src/credits/components/CreditTransactionListTable.js
@@ -10,6 +10,7 @@ import ReactTable from '../../app/components/ReactTable';
 import formatNumeric from '../../app/utilities/formatNumeric';
 import history from '../../app/History';
 import ROUTES_CREDIT_REQUESTS from '../../app/routes/CreditRequests';
+import ROUTES_CREDIT_TRANSFERS from '../../app/routes/CreditTransfers';
 import ROUTES_CREDITS from '../../app/routes/Credits';
 
 const CreditTransactionListTable = (props) => {
@@ -129,6 +130,12 @@ const CreditTransactionListTable = (props) => {
 
               const { transactionType } = item.transactionType;
               switch (transactionType.toLowerCase()) {
+                case 'credit transfer':
+                  history.push(
+                    ROUTES_CREDIT_TRANSFERS.DETAILS.replace(/:id/g, item.foreignKey),
+                    { href: ROUTES_CREDITS.LIST },
+                  );
+                  break;
                 case 'validation':
                   history.push(
                     ROUTES_CREDIT_REQUESTS.DETAILS.replace(/:id/g, item.foreignKey),

--- a/frontend/src/credits/components/CreditTransfersDetailsPage.js
+++ b/frontend/src/credits/components/CreditTransfersDetailsPage.js
@@ -254,7 +254,6 @@ const CreditTransfersDetailsPage = (props) => {
       <textarea testid="transfer-comment" name="transfer-comment" className="col-sm-11" rows="3" onChange={(event) => { setComment(event.target.value); }} value={comment} disabled={allChecked} />
     </div>
   );
-
   return (
     <div id="credit-transfers-details" className="page">
       {modal}
@@ -263,7 +262,7 @@ const CreditTransfersDetailsPage = (props) => {
           <h2>Light Duty Vehicle Credit Transfer</h2>
         </div>
       </div>
-      {transferRole.governmentDirector && errorMessage
+      {transferRole.governmentDirector && errorMessage !== []
       && (
       <Alert
         title="Error"

--- a/frontend/src/credits/components/CreditTransfersDetailsPage.js
+++ b/frontend/src/credits/components/CreditTransfersDetailsPage.js
@@ -165,9 +165,9 @@ const CreditTransfersDetailsPage = (props) => {
   );
   const transferValue = (
     <div className="text-blue">
-      for a total value of ${submission.creditTransferContent.reduce(
+      for a total value of ${(submission.creditTransferContent.reduce(
       (a, v) => a + v.dollarValue * v.creditValue, 0,
-    )} Canadian dollars.
+    ).toFixed(2))} Canadian dollars.
     </div>
   );
   let latestRescind = false;

--- a/frontend/src/credits/components/CreditTransfersDetailsTable.js
+++ b/frontend/src/credits/components/CreditTransfersDetailsTable.js
@@ -40,7 +40,7 @@ const CreditTransfersDetailsTable = (props) => {
     className: 'text-right',
   }, {
     Header: 'Total',
-    accessor: (item) => (`$${item.creditValue * item.dollarValue}`),
+    accessor: (item) => (`$${(item.creditValue * item.dollarValue).toFixed(2)}`),
     id: 'total',
     className: 'text-right',
   },

--- a/frontend/src/credits/components/CreditTransfersForm.js
+++ b/frontend/src/credits/components/CreditTransfersForm.js
@@ -92,7 +92,7 @@ const CreditTransfersForm = (props) => {
               }}
               optionalText="Submit Notice"
               buttonTooltip={submitTooltip}
-              disabled={checkboxes.length < assertions.length}
+              disabled={checkboxes.length < assertions.length || unfilledRow}
             />
             )}
           </span>

--- a/frontend/src/credits/components/CreditTransfersForm.js
+++ b/frontend/src/credits/components/CreditTransfersForm.js
@@ -45,8 +45,8 @@ const CreditTransfersForm = (props) => {
       handleSubmit={() => { setShowModal(false); handleSubmit(modalType.type); }}
       modalClass="w-75"
       showModal={showModal}
-      confirmClass={modalType === 'SUBMITTED' ? 'button primary' : 'btn-outline-danger'}
-      icon={modalType === 'SUBMITTED' ? <FontAwesomeIcon icon="paper-plane" /> : <FontAwesomeIcon icon="trash" />}
+      confirmClass={modalType.type === 'SUBMITTED' ? 'button primary' : 'btn-outline-danger'}
+      icon={modalType.type === 'SUBMITTED' ? <FontAwesomeIcon icon="paper-plane" /> : <FontAwesomeIcon icon="trash" />}
     >
       <div>
         <div><br /><br /></div>

--- a/frontend/src/credits/components/CreditTransfersForm.js
+++ b/frontend/src/credits/components/CreditTransfersForm.js
@@ -35,6 +35,7 @@ const CreditTransfersForm = (props) => {
     transferComments,
     submission,
   } = props;
+  console.log(errorMessage)
   const [showModal, setShowModal] = useState(false);
   const [modalType, setModalType] = useState({ type: '', buttonText: '', message: '' });
   const submitTooltip = 'You must acknowledge the three confirmation checkboxes prior to submitting this transfer.';

--- a/frontend/src/credits/components/CreditTransfersForm.js
+++ b/frontend/src/credits/components/CreditTransfersForm.js
@@ -35,7 +35,6 @@ const CreditTransfersForm = (props) => {
     transferComments,
     submission,
   } = props;
-  console.log(errorMessage)
   const [showModal, setShowModal] = useState(false);
   const [modalType, setModalType] = useState({ type: '', buttonText: '', message: '' });
   const submitTooltip = 'You must acknowledge the three confirmation checkboxes prior to submitting this transfer.';

--- a/frontend/src/credits/components/CreditTransfersListTable.js
+++ b/frontend/src/credits/components/CreditTransfersListTable.js
@@ -87,13 +87,13 @@ const CreditTransfersListTable = (props) => {
     accessor: (item) => {
       const { status } = item;
       const formattedStatus = formatStatus(status);
- 
+
       if (formattedStatus === 'validated') {
         return 'recorded';
       }
       if (formattedStatus === 'recommend rejection') {
         return 'recommend rejection';
-      } 
+      }
       if (formattedStatus === 'recommend approval') {
         return 'recommend approval';
       }
@@ -103,19 +103,13 @@ const CreditTransfersListTable = (props) => {
       if (formattedStatus === 'submitted') {
         return 'submitted to transfer partner';
       }
-      //find out who it was rescinded by
       if (formattedStatus === 'rescind pre approval' || formattedStatus === 'rescinded') {
         const rescindorg = statusFilter(item).createUser.organization.name;
         return `rescinded by ${rescindorg}`;
       }
-      // if (formattedStatus === 'rescind pre approval' || formattedStatus === 'rescinded') {
-      //   return 'rescinded by buyer';
-      // }
-      // rejected by Government
       if (formattedStatus === 'rejected') {
         return 'rejected by government';
       }
-      // rejected by transfer partner
       if (formattedStatus === 'disapproved') {
         return 'rejected by transfer partner';
       }
@@ -156,8 +150,8 @@ const CreditTransfersListTable = (props) => {
         if (row && row.original) {
           return {
             onClick: () => {
-              const { id, status } = row.original;
-              if (status === 'DRAFT' || status === 'RESCINDED' || status === 'RESCIND_PRE_APPROVAL') {
+              const { id, status, debitFrom } = row.original;
+              if ((status === 'DRAFT' || status === 'RESCINDED' || status === 'RESCIND_PRE_APPROVAL') && user.organization.id === debitFrom.id) {
                 history.push(ROUTES_CREDIT_TRANSFERS.EDIT.replace(/:id/g, id));
               } else {
                 history.push(ROUTES_CREDIT_TRANSFERS.DETAILS.replace(/:id/g, id), filtered);


### PR DESCRIPTION
1. When a BCeID user creates a transfer notice with multiple lines it is possible to skip over (not interact with) the $ value field and still submit. In this case the submit button is enables and the save button is disabled when it should be the other way round.
2. moved to Jira-404
3. IDIR user should not be able to see transfer notices that are rejected or rescinded before they are submitted to government
4. IDIR user briefly sees the BCeID transfer notice form page when they  click to view a rescinded transfer. Please change so they don't see that form.
5. When the IDIR Director is viewing a transfer notices the new balance of Tesla (the seller) appeared with many decimal places. Please change to limit the balance to 2 decimal places. 
6. The Director is receiving the 'Insufficient error' warning incorrectly (i.e when there are enough credits in the balance of the seller)
7. After a transfer has been recorded the BCeID users cannot click on the transfer to see the details - the line in the table is not clickable