### PR TITLE
ZEVA-420: Fixed icbc current to always showing latest date

### DIFF
--- a/frontend/src/credits/components/CreditRequestDetailsPage.js
+++ b/frontend/src/credits/components/CreditRequestDetailsPage.js
@@ -156,10 +156,11 @@ const CreditRequestDetailsPage = (props) => {
         </div>
       </div>
       {analystAction
+      && submission.icbcCurrentTo
       && (
       <div className="row my-1">
         <div className="col-sm-12">
-          ICBC data current to: {uploadDate ? moment(uploadDate).format('MMM D, YYYY') : 'no ICBC data uploaded yet.'}
+          ICBC data current to: {moment(submission.icbcCurrentTo).format('MMM D, YYYY')}
         </div>
       </div>
       )}


### PR DESCRIPTION
Changelog:
- Changed how icbc is current to is populated
- New serializer field for icbc current to which looks at the timestamp on when the checked status was created and look for an upload date closest to that without going over