### PR TITLE
ZEVA-439: Fixed duplicate transactions being created

### DIFF
--- a/backend/api/services/credit_transaction.py
+++ b/backend/api/services/credit_transaction.py
@@ -172,7 +172,7 @@ def calculate_insufficient_credits(org_id):
 @transaction.atomic
 def validate_transfer(transfer):
     initiating_supplier = transfer.debit_from
-    recieving_supplier = transfer.credit_to
+    receiving_supplier = transfer.credit_to
     content = transfer.credit_transfer_content.all()
     supplier_totals = aggregate_credit_balance_details(initiating_supplier.id)
     credit_total = {}
@@ -209,65 +209,67 @@ def validate_transfer(transfer):
                 credit_total[model_year] = {credit_type: credit_value}
             else:
                 credit_total[model_year][credit_type] += credit_value
-            for year, v in credit_total.items():
-                for credit_class, credit_value in v.items():
-                    # add record for each unique combination to credit transaction table
-                    added_transaction = CreditTransaction.objects.create(
-                        create_user=transfer.update_user,
-                        credit_class=CreditClass.objects.get(
-                            id=credit_class
-                        ),
-                        debit_from=transfer.debit_from,
-                        credit_to=transfer.credit_to,
-                        model_year_id=year,
-                        number_of_credits=1,
-                        credit_value=credit_value,
-                        transaction_type=CreditTransactionType.objects.get(
-                            transaction_type="Credit Transfer"
-                        ),
-                        total_value=1 * credit_value,
-                        update_user=transfer.update_user,
-                        weight_class=WeightClass.objects.get(
-                            weight_class_code='LDV')
-                    )
 
-                    CreditTransferCreditTransaction.objects.create(
-                        create_user=transfer.update_user,
-                        credit_transaction_id=added_transaction.id,
-                        credit_transfer_id=transfer.id,
-                        update_user=transfer.update_user,
-                    )
-            for each_supplier in [initiating_supplier, recieving_supplier]:
-                reduce_total = each_supplier == transfer.debit_from
-                add_total = each_supplier == transfer.credit_to
-                for credit_class, credit_value in credit_total_no_years.items():
-                    new_balance = 0
-                    current_balance = AccountBalance.objects.filter(
-                        credit_class=credit_class,
-                        organization_id=each_supplier.id,
-                        expiration_date=None
-                        ).order_by('-id').first()
-                    if current_balance:
-                        if reduce_total:
-                            new_balance = Decimal(current_balance.balance) - \
-                                Decimal(credit_value)
-                        if add_total:
-                            new_balance = Decimal(current_balance.balance) + \
-                                Decimal(credit_value)
-                        current_balance.expiration_date = date.today()
-                        current_balance.save()
-                    else:
-                        if add_total:
-                            new_balance = credit_value
-                        elif reduce_total:
-                            ## if they don't have a balance we should probably not allow this transfer
-                            new_balance = 0 - credit_value
-                    AccountBalance.objects.create(
-                        balance=new_balance,
-                        effective_date=date.today(),
-                        credit_class=CreditClass.objects.get(
-                            id=credit_class
-                        ),
-                        credit_transaction=added_transaction,
-                        organization_id=each_supplier.id
-                    )
+    for year, v in credit_total.items():
+        for credit_class, credit_value in v.items():
+            # add record for each unique combination to credit transaction table
+            added_transaction = CreditTransaction.objects.create(
+                create_user=transfer.update_user,
+                credit_class=CreditClass.objects.get(
+                    id=credit_class
+                ),
+                debit_from=transfer.debit_from,
+                credit_to=transfer.credit_to,
+                model_year_id=year,
+                number_of_credits=1,
+                credit_value=credit_value,
+                transaction_type=CreditTransactionType.objects.get(
+                    transaction_type="Credit Transfer"
+                ),
+                total_value=1 * credit_value,
+                update_user=transfer.update_user,
+                weight_class=WeightClass.objects.get(
+                    weight_class_code='LDV')
+            )
+
+            CreditTransferCreditTransaction.objects.create(
+                create_user=transfer.update_user,
+                credit_transaction_id=added_transaction.id,
+                credit_transfer_id=transfer.id,
+                update_user=transfer.update_user,
+            )
+
+    for each_supplier in [initiating_supplier, receiving_supplier]:
+        reduce_total = each_supplier == transfer.debit_from
+        add_total = each_supplier == transfer.credit_to
+        for credit_class, credit_value in credit_total_no_years.items():
+            new_balance = 0
+            current_balance = AccountBalance.objects.filter(
+                credit_class=credit_class,
+                organization_id=each_supplier.id,
+                expiration_date=None
+                ).order_by('-id').first()
+            if current_balance:
+                if reduce_total:
+                    new_balance = Decimal(current_balance.balance) - \
+                        Decimal(credit_value)
+                if add_total:
+                    new_balance = Decimal(current_balance.balance) + \
+                        Decimal(credit_value)
+                current_balance.expiration_date = date.today()
+                current_balance.save()
+            else:
+                if add_total:
+                    new_balance = credit_value
+                elif reduce_total:
+                    ## if they don't have a balance we should probably not allow this transfer
+                    new_balance = 0 - credit_value
+            AccountBalance.objects.create(
+                balance=new_balance,
+                effective_date=date.today(),
+                credit_class=CreditClass.objects.get(
+                    id=credit_class
+                ),
+                credit_transaction=added_transaction,
+                organization_id=each_supplier.id
+            )

--- a/frontend/src/credits/components/CreditTransactions.js
+++ b/frontend/src/credits/components/CreditTransactions.js
@@ -34,7 +34,9 @@ const CreditTransactions = (props) => {
 
     const found = transactions.findIndex(
       (transaction) => (transaction.foreignKey === item.foreignKey
-        && transaction.transactionType === item.transactionType),
+        && transaction.transactionType
+        && item.transactionType
+        && transaction.transactionType.transactionType === item.transactionType.transactionType),
     );
 
     if (found >= 0) {
@@ -56,6 +58,8 @@ const CreditTransactions = (props) => {
         transactionType: item.transactionType,
       });
     }
+
+    console.error(transactions);
   });
 
   const balances = {};

--- a/frontend/src/credits/components/CreditTransactions.js
+++ b/frontend/src/credits/components/CreditTransactions.js
@@ -58,8 +58,6 @@ const CreditTransactions = (props) => {
         transactionType: item.transactionType,
       });
     }
-
-    console.error(transactions);
   });
 
   const balances = {};


### PR DESCRIPTION
Changelog:
- Moved the credit transactions creation outside the initial loop when we're building the credits to be added
- Moved the account balance update outside that loop as well
- Fixed an issue where transactions are not being merged together properly