### PR TITLE
ZEVA-442: Credit Transfer status change

### DIFF
--- a/frontend/src/credits/components/CreditTransfersListTable.js
+++ b/frontend/src/credits/components/CreditTransfersListTable.js
@@ -98,7 +98,7 @@ const CreditTransfersListTable = (props) => {
         return 'recommend approval';
       }
       if (formattedStatus === 'approved') {
-        return 'approved by transfer partner';
+        return 'submitted to government';
       }
       if (formattedStatus === 'submitted') {
         return 'submitted to transfer partner';

--- a/frontend/src/dashboard/components/ActionsBceid.js
+++ b/frontend/src/dashboard/components/ActionsBceid.js
@@ -134,7 +134,7 @@ const ActionsBceid = (props) => {
           icon="exchange-alt"
           boldText="Credit Transfer"
           regularText={`${activityCount.transfersAwaitingPartner} awaiting partner confirmation`}
-          linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Submitted`}
+          linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Submitted%20to%20Transfer%20Partner`}
         />
         )}
         {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED
@@ -146,7 +146,7 @@ const ActionsBceid = (props) => {
           icon="exchange-alt"
           boldText="Credit Transfer"
           regularText={`${activityCount.transfersAwaitingGovernment} awaiting  Government of B.C. action`}
-          linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Approved`}
+          linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Submitted%20to%20Government`}
         />
         )}
         {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED

--- a/frontend/src/dashboard/components/ActionsIdir.js
+++ b/frontend/src/dashboard/components/ActionsIdir.js
@@ -90,7 +90,7 @@ const ActionsIdir = (props) => {
           icon="exchange-alt"
           boldText="Credit Transfer"
           regularText={`${activityCount.transfersAwaitingPartner} awaiting partner confirmation`}
-          linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Submitted`}
+          linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Submitted%20to%20Transfer%20Partner`}
         />
         )}
         {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED
@@ -102,7 +102,7 @@ const ActionsIdir = (props) => {
           icon="exchange-alt"
           boldText="Credit Transfer"
           regularText={`${activityCount.transfersAwaitingAnalyst} require analyst recommendation`}
-          linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Approved`}
+          linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Submitted%20to%20Government`}
         />
         )}
         {CONFIG.FEATURES.CREDIT_TRANSFERS.ENABLED


### PR DESCRIPTION
-Change status from "approved by transfer partner" to "submitted to government" when transfer partner approves the transfer for both bceid and idir users.
-Also, changed dashboard alert filter to new status.