### PR TITLE
ZEVA-462: Compliance Raio and Compliance Calculator to be configurable

### DIFF
--- a/frontend/src/app/components/ComplianceTabs.js
+++ b/frontend/src/app/components/ComplianceTabs.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
+
+import CONFIG from '../config';
 import ROUTES_COMPLIANCE from '../routes/Compliance';
 import CustomPropTypes from '../utilities/props';
 
@@ -13,19 +15,24 @@ const ComplianceTabs = (props) => {
       key="tabs"
       role="tablist"
     >
+      {CONFIG.FEATURES.MODEL_YEAR_REPORT.ENABLED && (
       <li
         className={`nav-item ${(active === 'reports') ? 'active' : ''}`}
         role="presentation"
       >
         <Link to={ROUTES_COMPLIANCE.REPORTS}>Model Year Reports</Link>
       </li>
+      )}
+      {CONFIG.FEATURES.COMPLIANCE_RATIOS.ENABLED && (
       <li
         className={`nav-item ${(active === 'ratios') ? 'active' : ''}`}
         role="presentation"
       >
         <Link to={ROUTES_COMPLIANCE.RATIOS}>Compliance Ratios</Link>
       </li>
+      )}
       {!user.isGovernment && user.hasPermission('EDIT_SALES')
+        && CONFIG.FEATURES.COMPLIANCE_CALCULATOR.ENABLED
         && (
         <li
           className={`nav-item ${(active === 'calculator') ? 'active' : ''}`}

--- a/frontend/src/app/components/Navbar.js
+++ b/frontend/src/app/components/Navbar.js
@@ -178,7 +178,7 @@ class Navbar extends Component {
 
                     return true;
                   }}
-                  to={ROUTES_COMPLIANCE.REPORTS}
+                  to={CONFIG.FEATURES.MODEL_YEAR_REPORT.ENABLED ? ROUTES_COMPLIANCE.REPORTS : ROUTES_COMPLIANCE.RATIOS}
                 >
                   <span>Compliance Reporting</span>
                 </NavLink>

--- a/frontend/src/app/config.js
+++ b/frontend/src/app/config.js
@@ -26,6 +26,12 @@ const CONFIG = {
     CREDIT_TRANSACTIONS: {
       ENABLED: getConfig('credit_transactions.enabled', false),
     },
+    COMPLIANCE_CALCULATOR: {
+      ENABLED: getConfig('compliance_calculator.enabled', false),
+    },
+    COMPLIANCE_RATIOS: {
+      ENABLED: getConfig('compliance_ratios.enabled', false),
+    },
     COMPLIANCE_REPORT: {
       ENABLED: getConfig('compliance_report.enabled', false),
     },

--- a/frontend/src/app/config/features.js
+++ b/frontend/src/app/config/features.js
@@ -1,5 +1,7 @@
 window.zeva_config = {
   'compliance_report.enabled': true,
+  'compliance_calculator.enabled': true,
+  'compliance_ratios.enabled': true,
   'credit_transfers.enabled': true,
   'credit_transactions.enabled': true,
   'initiative_agreements.enabled': false,


### PR DESCRIPTION
Changelog:
- Re-added model year report (this is whether to show the tab 'not navigation')
- Compliance Ratio is not configurable
- Compliance Calculator is not configurable