### PR TITLE
Removed the old model year report navigation bar

### DIFF
--- a/frontend/src/app/components/Navbar.js
+++ b/frontend/src/app/components/Navbar.js
@@ -184,17 +184,6 @@ class Navbar extends Component {
                 </NavLink>
               </li>
               )}
-              {CONFIG.FEATURES.MODEL_YEAR_REPORT.ENABLED && (
-              <li className="nav-item">
-                <NavLink
-                  activeClassName="active"
-                  to="/model-year-report"
-                >
-                  <span>Model Year Report</span>
-                </NavLink>
-              </li>
-              )}
-
               {CONFIG.FEATURES.CREDIT_TRANSACTIONS.ENABLED
               && typeof user.hasPermission === 'function'
               && ((!user.isGovernment && user.hasPermission('EDIT_SALES'))


### PR DESCRIPTION
I didn't realize we still have that old code for the model year report