### PR TITLE
ZEVA-476:Model Year Compliance Report - Confirmations

### DIFF
--- a/backend/api/fixtures/operational/0022_update_signing_authority_assertions.py
+++ b/backend/api/fixtures/operational/0022_update_signing_authority_assertions.py
@@ -1,0 +1,62 @@
+from django.db import transaction
+
+from api.management.data_script import OperationalDataScript
+from api.models.signing_authority_assertion import SigningAuthorityAssertion
+
+
+class UpdateSigningAuthorityAssertions(OperationalDataScript):
+    """
+    Update the assertions for the compliance report
+    """
+    is_revertable = False
+    comment = 'Update the assertions for the compliance report'
+
+    def check_run_preconditions(self):
+        return True
+
+    @transaction.atomic
+    def run(self):
+        SigningAuthorityAssertion.objects.get_or_create(
+            description="I confirm the legal name, address for service, "
+                        "records address, the supplier classification "
+                        "and vehicle makes supplier are correct.",
+            display_order="4",
+            effective_date="2020-01-01",
+            module="supplier_information"
+        )
+        SigningAuthorityAssertion.objects.get_or_create(
+            description="I confirm the consumer sales figures are correct.",
+            display_order="5",
+            effective_date="2020-01-01",
+            module="consumer_sales"
+        )
+        SigningAuthorityAssertion.objects.get_or_create(
+            description="I confirm the model year, type and range of each ZEV "
+                        "model sold or leased are correct.",
+            display_order="6",
+            effective_date="2020-01-01",
+            module="consumer_sales"
+        )
+        SigningAuthorityAssertion.objects.get_or_create(
+            description="I confirm the credit balances are correct",
+            display_order="7",
+            effective_date="2020-01-01",
+            module="compliance_obligation"
+        )
+        SigningAuthorityAssertion.objects.get_or_create(
+            description="I confirm the number, model year, vehicle class "
+                        "and ZEV class of credits issued, transfered or added are correct.",
+            display_order="8",
+            effective_date="2020-01-01",
+            module="compliance_obligation"
+        )
+        SigningAuthorityAssertion.objects.get_or_create(
+            description="I confirm the number, vehicle class "
+                        "and ZEV class of credits debited are correct.",
+            display_order="9",
+            effective_date="2020-01-01",
+            module="compliance_obligation"
+        )
+
+
+script_class = UpdateSigningAuthorityAssertions

--- a/backend/api/serializers/model_year_report.py
+++ b/backend/api/serializers/model_year_report.py
@@ -4,6 +4,7 @@ from rest_framework.serializers import ModelSerializer, \
     ListField
 
 from api.models.model_year import ModelYear
+from api.models.model_year_report_confirmation import ModelYearReportConfirmation
 from api.models.model_year_report import ModelYearReport
 from api.models.model_year_report_address import ModelYearReportAddress
 from api.models.model_year_report_make import ModelYearReportMake
@@ -65,6 +66,7 @@ class ModelYearReportSaveSerializer(
         organization = request.user.organization
         makes = validated_data.pop('makes')
         model_year = validated_data.pop('model_year')
+        confirmations = request.data.get('confirmations')
 
         report = ModelYearReport.objects.create(
             model_year_id=model_year.id,
@@ -75,6 +77,15 @@ class ModelYearReportSaveSerializer(
             create_user=request.user.username,
             update_user=request.user.username,
         )
+
+        for confirmation in confirmations:
+            ModelYearReportConfirmation.objects.create(
+                create_user=request.user.username,
+                model_year_report=report,
+                has_accepted=True,
+                title=request.user.title,
+                signing_authority_assertion_id=confirmation
+                )
 
         for make in makes:
             ModelYearReportMake.objects.create(

--- a/backend/api/serializers/signing_authority_assertion.py
+++ b/backend/api/serializers/signing_authority_assertion.py
@@ -7,6 +7,6 @@ class SigningAuthorityAssertionSerializer(serializers.ModelSerializer):
     class Meta:
         model = SigningAuthorityAssertion
         fields = (
-            'id', 'description', 'effective_date', 'expiration_date',
+            'id', 'description', 'effective_date', 'expiration_date', 'module',
             'display_order'
         )

--- a/backend/api/viewsets/model_year_report_vehicle.py
+++ b/backend/api/viewsets/model_year_report_vehicle.py
@@ -4,6 +4,7 @@ from api.models.model_year_report_vehicle import ModelYearReportVehicle
 from api.models.model_year_report import ModelYearReport
 from api.models.vehicle import Vehicle
 from api.models.model_year import ModelYear
+from api.models.model_year_report_confirmation import ModelYearReportConfirmation
 from api.models.model_year_report_previous_sales import ModelYearReportPreviousSales
 from rest_framework.response import Response
 
@@ -32,17 +33,26 @@ class ModelYearReportVehicleViewSet(mixins.ListModelMixin, mixins.CreateModelMix
         model_year_report_id = request.data.get('model_year_report_id')
         model_year_report_ldv_sales = request.data.get('ldv_sales')
         previous_sales = request.data.get('previous_sales')
+        confirmations = request.data.get('confirmation')
 
+        report = ModelYearReport.objects.get(id=model_year_report_id)
+
+        """ 
+        Update LDV sales
+        """
+        model_year_report_update = ModelYearReport.objects.filter(
+            id=model_year_report_id
+        )
+        model_year_report_update.update(ldv_sales=model_year_report_ldv_sales)
+
+        """ 
+        Save/Update vehicle information
+        """
         vehicles_delete = ModelYearReportVehicle.objects.filter(
             model_year_report_id=model_year_report_id
         )
         vehicles_delete.delete()
 
-        model_year_report_update = ModelYearReport.objects.filter(
-            id=model_year_report_id
-        )
-        model_year_report_update.update(ldv_sales=model_year_report_ldv_sales)
-        
         for vehicle in vehicles:
             serializer = ModelYearReportVehicleSaveSerializer(
                 data=vehicle,
@@ -51,6 +61,9 @@ class ModelYearReportVehicleViewSet(mixins.ListModelMixin, mixins.CreateModelMix
             serializer.is_valid(raise_exception=True)
             model_year_report_vehicle = serializer.save()
 
+        """ 
+        Save/Update previous years LDV sales information
+        """
         previous_year_delete = ModelYearReportPreviousSales.objects.filter(
             model_year_report_id=model_year_report_id
         )
@@ -61,9 +74,28 @@ class ModelYearReportVehicleViewSet(mixins.ListModelMixin, mixins.CreateModelMix
             model_year_report_previous_sale = ModelYearReportPreviousSales.objects.create(
                 previous_sales=previous_sale.get('ldv_sales'),
                 model_year=ModelYear.objects.get(name=previous_sale.get('model_year')),
-                model_year_report=ModelYearReport.objects.get(id=model_year_report_id)
+                model_year_report=report
             )
             model_year_report_previous_sale.save()
+
+        """ 
+        Save/Update confirmation
+        """
+        
+        for confirmation in confirmations:
+
+            confirmation_delete = ModelYearReportConfirmation.objects.filter(
+            signing_authority_assertion_id=confirmation).filter(model_year_report=report)
+            confirmation_delete.delete()
+
+            consumer_sales_confirmation = ModelYearReportConfirmation.objects.create(
+                create_user=request.user.username,
+                model_year_report=report,
+                has_accepted=True,
+                title=request.user.title,
+                signing_authority_assertion_id=confirmation
+            )
+            consumer_sales_confirmation.save()
 
         return Response(
            {"status":"saved"}

--- a/backend/api/viewsets/signing_authority_assertion.py
+++ b/backend/api/viewsets/signing_authority_assertion.py
@@ -29,7 +29,6 @@ class SigningAuthorityAssertionViewSet(
         as_of = datetime.today()
 
         return SigningAuthorityAssertion.objects.filter(
-            module="credit_transfer",
             effective_date__lte=as_of
         ).filter(
             Q(expiration_date__gte=as_of) | Q(expiration_date=None)

--- a/frontend/src/compliance/CreditActivityContainer.js
+++ b/frontend/src/compliance/CreditActivityContainer.js
@@ -5,6 +5,7 @@ import ROUTES_CREDITS from '../app/routes/Credits';
 import CustomPropTypes from '../app/utilities/props';
 import ComplianceReportTabs from './components/ComplianceReportTabs';
 import CreditActivityDetailsPage from './components/CreditActivityDetailsPage';
+import ROUTES_SIGNING_AUTHORITY_ASSERTIONS from '../app/routes/SigningAuthorityAssertions';
 
 const CreditActivityContainer = (props) => {
   const { keycloak, user } = props;
@@ -18,6 +19,20 @@ const CreditActivityContainer = (props) => {
   const [balances, setBalances] = useState([]);
   const [creditTransactions, setCreditTransactions] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [assertions, setAssertions] = useState([]);
+  const [checkboxes, setCheckboxes] = useState([]);
+
+  const handleCheckboxClick = (event) => {
+    if (!event.target.checked) {
+      const checked = checkboxes.filter((each) => Number(each) !== Number(event.target.id));
+      setCheckboxes(checked);
+    }
+
+    if (event.target.checked) {
+      const checked = checkboxes.concat(event.target.id);
+      setCheckboxes(checked);
+    }
+  };
 
   const refreshDetails = () => {
     setLoading(true);
@@ -29,7 +44,12 @@ const CreditActivityContainer = (props) => {
       setCreditTransactions(response.data);
     });
 
-    Promise.all([balancePromise, listPromise]).then(() => {
+    const listAssertion = axios.get(ROUTES_SIGNING_AUTHORITY_ASSERTIONS.LIST).then((response) => {
+      let filteredAsserstions = response.data.filter((data) => data.module == 'compliance_obligation');
+      setAssertions(filteredAsserstions);
+    });
+
+    Promise.all([balancePromise, listPromise, listAssertion]).then(() => {
       setLoading(false);
     });
   };
@@ -46,6 +66,9 @@ const CreditActivityContainer = (props) => {
         loading={loading}
         transactions={creditTransactions}
         user={user}
+        assertions={assertions}
+        checkboxes={checkboxes}
+        handleCheckboxClick={handleCheckboxClick}
       />
     </>
   );

--- a/frontend/src/compliance/SupplierInformationContainer.js
+++ b/frontend/src/compliance/SupplierInformationContainer.js
@@ -9,10 +9,15 @@ import ROUTES_VEHICLES from '../app/routes/Vehicles';
 import CustomPropTypes from '../app/utilities/props';
 import ComplianceReportTabs from './components/ComplianceReportTabs';
 import SupplierInformationDetailsPage from './components/SupplierInformationDetailsPage';
+import ROUTES_SIGNING_AUTHORITY_ASSERTIONS from '../app/routes/SigningAuthorityAssertions';
 
 const SupplierInformationContainer = (props) => {
   const { keycloak, user } = props;
   const { id } = useParams();
+  const [assertions, setAssertions] = useState([]);
+  const [checkboxes, setCheckboxes] = useState([]);
+  const [disabledCheckboxes, setDisabledCheckboxes] = useState('');
+
   const reportStatuses = {
     assessment: '',
     consumerSales: '',
@@ -47,11 +52,25 @@ const SupplierInformationContainer = (props) => {
     const data = {
       makes,
       modelYear: moment().year(),
+      confirmations: checkboxes,
     };
 
     axios.post(ROUTES_COMPLIANCE.REPORTS, data).then((response) => {
       history.push(ROUTES_COMPLIANCE.REPORT_SUPPLIER_INFORMATION.replace(':id', response.data.id));
+      setDisabledCheckboxes('disabled');
     });
+  };
+
+  const handleCheckboxClick = (event) => {
+    if (!event.target.checked) {
+      const checked = checkboxes.filter((each) => Number(each) !== Number(event.target.id));
+      setCheckboxes(checked);
+    }
+
+    if (event.target.checked) {
+      const checked = checkboxes.concat(event.target.id);
+      setCheckboxes(checked);
+    }
   };
 
   const refreshDetails = () => {
@@ -59,6 +78,10 @@ const SupplierInformationContainer = (props) => {
       const { data } = response;
       setMakes([...new Set(data.map((vehicle) => vehicle.make.toUpperCase()))]);
       setLoading(false);
+    });
+    axios.get(ROUTES_SIGNING_AUTHORITY_ASSERTIONS.LIST).then((response) => {
+      const filteredAsserstions = response.data.filter((data) => data.module == 'supplier_information');
+      setAssertions(filteredAsserstions);
     });
   };
 
@@ -83,6 +106,10 @@ const SupplierInformationContainer = (props) => {
         make={make}
         makes={makes}
         user={user}
+        assertions={assertions}
+        checkboxes={checkboxes}
+        handleCheckboxClick={handleCheckboxClick}
+        disabledCheckboxes={disabledCheckboxes}
       />
     </>
   );

--- a/frontend/src/compliance/components/ComplianceReportSignOff.js
+++ b/frontend/src/compliance/components/ComplianceReportSignOff.js
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import ReactTooltip from 'react-tooltip';
+import CustomPropTypes from '../../app/utilities/props';
+
+const ComplianceReportSignOff = (props) => {
+  const {
+    assertions,
+    checkboxes,
+    handleCheckboxClick,
+    disabledCheckboxes,
+    user,
+  } = props;
+
+  return (
+    <div id="compliance-sign-off">
+      <ReactTooltip />
+      {assertions.map((assertion) => (
+        <div key={assertion.id}>
+          <div className="d-inline-block align-middle my-2 ml-2 mr-1">
+            <input
+              checked={checkboxes.findIndex((checkbox) => (parseInt(checkbox, 10) === parseInt(assertion.id, 10))) >= 0}
+              id={assertion.id}
+              name="confirmations"
+              onChange={(event) => { handleCheckboxClick(event); }}
+              type="checkbox"
+              disabled={disabledCheckboxes}
+            />
+          </div>
+          <label className="d-inline ml-2" htmlFor={assertion.id} id="confirmation-text">
+            {assertion.description}
+          </label>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+ComplianceReportSignOff.defaultProps = {
+  assertions: [],
+  checkboxes: [],
+};
+ComplianceReportSignOff.propTypes = {
+  assertions: PropTypes.arrayOf(PropTypes.shape()),
+  checkboxes: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ),
+  handleCheckboxClick: PropTypes.func.isRequired,
+  user: CustomPropTypes.user.isRequired,
+  disabledCheckboxes: PropTypes.string,
+};
+
+export default ComplianceReportSignOff;

--- a/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
+++ b/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
@@ -5,6 +5,7 @@ import Loading from '../../app/components/Loading';
 import ComplianceReportAlert from './ComplianceReportAlert';
 import Button from '../../app/components/Button';
 import { now } from 'moment';
+import ComplianceReportSignOff from './ComplianceReportSignOff';
 import ConsumerSalesLDVModalTable from '../components/ConsumerSalesLDVModelTable';
 
 const ConsumerSalesDetailsPage = (props) => {
@@ -16,7 +17,12 @@ const ConsumerSalesDetailsPage = (props) => {
     vehicles,
     confirmed,
     previousSales,
+    assertions,
+    checkboxes,
+    readOnly,
+    disabledCheckboxes,
     error,
+    handleCheckboxClick,
   } = props;
 
   const details = {
@@ -74,8 +80,13 @@ const ConsumerSalesDetailsPage = (props) => {
                     className="textbox-sales"
                     type="text"
                     onChange={handleChange}
+                    readOnly={readOnly}
                   ></input>
-                  {error && <span className="text-danger ml-2">2020 Model Year LDV Sales\Leases can't be blank</span>}
+                  {error && (
+                    <span className="text-danger ml-2">
+                      2020 Model Year LDV Sales\Leases can't be blank
+                    </span>
+                  )}
                 </form>
               </div>
             </div>
@@ -114,19 +125,14 @@ const ConsumerSalesDetailsPage = (props) => {
       </div>
       <div className="row">
         <div className="col-12 my-3">
-          <div className="px-3">
-            <input id="confirm-sales" name="confirm" type="checkbox" />{' '}
-            <label htmlFor="confirm">
-              I confirm the consumer sales figures are correct.
-            </label>
-          </div>
-          <div className="px-3">
-            <input id="confirm-model-info" name="confirm" type="checkbox" />{' '}
-            <label htmlFor="confirm">
-              I confirm the model year, type and range of each ZEV model sold or
-              leased are correct.
-            </label>
-          </div>
+          <ComplianceReportSignOff
+            assertions={assertions}
+            checkboxes={checkboxes}
+            handleCheckboxClick={handleCheckboxClick}
+            disabledCheckboxes={disabledCheckboxes}
+            user={user}
+            readOnly={readOnly}
+          />
         </div>
       </div>
 
@@ -161,6 +167,11 @@ ConsumerSalesDetailsPage.propTypes = {
   vehicles: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   confirmed: PropTypes.bool.isRequired,
   previousSales: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  error: PropTypes.bool.isRequired
+  error: PropTypes.bool.isRequired,
+  assertions: PropTypes.arrayOf(PropTypes.shape()),
+  checkboxes: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+  handleCheckboxClick: PropTypes.func.isRequired,
+  disabledCheckboxes: PropTypes.string.isRequired,
+  readOnly: PropTypes.bool.isRequired
 };
 export default ConsumerSalesDetailsPage;

--- a/frontend/src/compliance/components/CreditActivityDetailsPage.js
+++ b/frontend/src/compliance/components/CreditActivityDetailsPage.js
@@ -10,6 +10,7 @@ import CreditBalanceTable from '../../credits/components/CreditBalanceTable';
 import CreditTransactionListTable from '../../credits/components/CreditTransactionListTable';
 import CustomPropTypes from '../../app/utilities/props';
 import ComplianceReportAlert from './ComplianceReportAlert';
+import ComplianceReportSignOff from './ComplianceReportSignOff';
 
 const CreditActivityDetailsPage = (props) => {
   const {
@@ -17,6 +18,9 @@ const CreditActivityDetailsPage = (props) => {
     loading,
     transactions,
     user,
+    assertions,
+    checkboxes,
+    handleCheckboxClick,
   } = props;
 
   const details = {
@@ -87,17 +91,12 @@ const CreditActivityDetailsPage = (props) => {
 
       <div className="row">
         <div className="col-12 my-3">
-          <div className="px-3">
-            <input id="confirm" name="confirm" type="checkbox" /> <label htmlFor="confirm">I confirm the credit balances are correct.</label>
-          </div>
-
-          <div className="px-3">
-            <input id="confirm" name="confirm" type="checkbox" /> <label htmlFor="confirm">I confirm the number, model year, vehicle class and ZEV class of credits issued, transferred or added are correct.</label>
-          </div>
-
-          <div className="px-3">
-            <input id="confirm" name="confirm" type="checkbox" /> <label htmlFor="confirm">I confirm the number, vehicle class and ZEV class of credits debited are correct.</label>
-          </div>
+          <ComplianceReportSignOff
+            assertions={assertions}
+            checkboxes={checkboxes}
+            handleCheckboxClick={handleCheckboxClick}
+            user={user}
+          />
         </div>
       </div>
 
@@ -125,5 +124,8 @@ CreditActivityDetailsPage.propTypes = {
   loading: PropTypes.bool.isRequired,
   transactions: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   user: CustomPropTypes.user.isRequired,
+  assertions: PropTypes.arrayOf(PropTypes.shape()),
+  checkboxes: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+  handleCheckboxClick: PropTypes.func.isRequired,
 };
 export default CreditActivityDetailsPage;

--- a/frontend/src/compliance/components/SupplierInformationDetailsPage.js
+++ b/frontend/src/compliance/components/SupplierInformationDetailsPage.js
@@ -7,6 +7,7 @@ import Button from '../../app/components/Button';
 import Loading from '../../app/components/Loading';
 import CustomPropTypes from '../../app/utilities/props';
 import ComplianceReportAlert from './ComplianceReportAlert';
+import ComplianceReportSignOff from './ComplianceReportSignOff';
 
 const SupplierInformationDetailsPage = (props) => {
   const {
@@ -18,6 +19,10 @@ const SupplierInformationDetailsPage = (props) => {
     make,
     makes,
     user,
+    assertions,
+    checkboxes,
+    disabledCheckboxes,
+    handleCheckboxClick,
   } = props;
 
   const details = {
@@ -140,9 +145,13 @@ const SupplierInformationDetailsPage = (props) => {
 
       <div className="row">
         <div className="col-12 my-3">
-          <div className="px-3">
-            <input id="confirm" name="confirm" type="checkbox" /> <label htmlFor="confirm">I confirm the legal name, address for service, records address, the supplier classification and vehicle makes supplier are correct.</label>
-          </div>
+          <ComplianceReportSignOff
+            assertions={assertions}
+            checkboxes={checkboxes}
+            handleCheckboxClick={handleCheckboxClick}
+            user={user}
+            disabledCheckboxes={disabledCheckboxes}
+          />
         </div>
       </div>
 
@@ -180,5 +189,9 @@ SupplierInformationDetailsPage.propTypes = {
   make: PropTypes.string.isRequired,
   makes: PropTypes.arrayOf(PropTypes.string).isRequired,
   user: CustomPropTypes.user.isRequired,
+  assertions: PropTypes.arrayOf(PropTypes.shape()),
+  checkboxes: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+  handleCheckboxClick: PropTypes.func.isRequired,
+  disabledCheckboxes:PropTypes.string.isRequired,
 };
 export default SupplierInformationDetailsPage;

--- a/frontend/src/credits/CreditTransfersDetailsContainer.js
+++ b/frontend/src/credits/CreditTransfersDetailsContainer.js
@@ -33,7 +33,8 @@ const CreditTransfersDetailsContainer = (props) => {
       axios.get(ROUTES_CREDIT_TRANSFERS.DETAILS.replace(':id', id)),
       axios.get(ROUTES_SIGNING_AUTHORITY_ASSERTIONS.LIST),
     ]).then(axios.spread((response, assertionsResponse) => {
-      setAssertions(assertionsResponse.data);
+      const filteredAssertions = assertionsResponse.data.filter((data) => data.module == 'credit_transfer');
+      setAssertions(filteredAssertions);
       setSubmission(response.data);
       setSufficientCredit(response.data.sufficientCredits);
 

--- a/frontend/src/credits/CreditTransfersEditContainer.js
+++ b/frontend/src/credits/CreditTransfersEditContainer.js
@@ -191,7 +191,8 @@ const CreditTransfersEditContainer = (props) => {
     ]).then(axios.spread((orgResponse, yearsResponse, assertionsResponse) => {
       setOrganizations(orgResponse.data);
       setYears(yearsResponse.data);
-      setAssertions(assertionsResponse.data);
+      const filteredAssertions = assertionsResponse.data.filter((data) => data.module == 'credit_transfer');
+      setAssertions(filteredAssertions);
     }));
     if (!newTransfer) {
       axios.get(ROUTES_CREDIT_TRANSFERS.DETAILS.replace(/:id/gi, id)).then((response) => {


### PR DESCRIPTION
- added fixture to update assertion table with compliance report checkboxes.
- Updated SigningAuthorityAssertionViewSet, removed module="credit_transfer" filter and added filtering on the front end logic.
- Getting all checkboxes from the DB table and displaying them on different pages based on module value.
-  Saving checkbox confirmation values for supplier_information and consumer_sales pages.
(need to move checkbox logic from credit activity to new compliance obligation)