### PR TITLE
ZEVA-461,477:Model Year Report - Supplier Info and Consumer Sales page changes

### DIFF
--- a/frontend/src/app/css/ComplianceReport.scss
+++ b/frontend/src/app/css/ComplianceReport.scss
@@ -28,6 +28,10 @@
   .consumer-sales {
     border: 1px solid $border-grey;
   }
+  .previous-ldv-avg {
+    border: 1px solid $border-grey;
+    height: 94%;
+  }
   .ldv-sales,
   .previous-ldv-sales {
     background-color: $default-background-grey;

--- a/frontend/src/compliance/ConsumerSalesContainer.js
+++ b/frontend/src/compliance/ConsumerSalesContainer.js
@@ -20,12 +20,12 @@ const ConsumerSalesContainer = (props) => {
   const [confirmed, setConfirmed] = useState(false);
   const [checkboxes, setCheckboxes] = useState([]);
   const [disabledCheckboxes, setDisabledCheckboxes] = useState('');
+  const [firstYear, setFirstYear] = useState({modelYear:2019,ldvSales:0});
+  const [secondYear, setSecondYear] = useState({modelYear:2018,ldvSales:0});
+  const [thirdYear, setThirdYear] = useState({ modelYear: 2017, ldvSales: 0 });
+  const [avgSales, setAvgSales] = useState(0);
+
   const { id } = useParams();
-  let previousSales = [
-    { id: 1, modelYear: 2017, ldvSales: 7789 },
-    { id: 2, modelYear: 2018, ldvSales: 8123 },
-    { id: 3, modelYear: 2019, ldvSales: 9456 },
-  ];
 
   const reportStatuses = {
     assessment: '',
@@ -42,9 +42,48 @@ const ConsumerSalesContainer = (props) => {
       setLoading(false);
     });
     axios.get(ROUTES_SIGNING_AUTHORITY_ASSERTIONS.LIST).then((response) => {
-      let filteredAsserstions = response.data.filter((data) => data.module == 'consumer_sales');
-      setAssertions(filteredAsserstions);
+      const filteredAssertions = response.data.filter(
+        (data) => data.module === 'consumer_sales'
+      );
+      setAssertions(filteredAssertions);
     });
+  };
+
+  const handleInputChange = (event) => {
+    const { id, value } = event.target;
+    if (id === 'first') {
+      if (value === '') {
+        setFirstYear({ ...firstYear, ldvSales: 0 });
+        averageLdvSales(0, secondYear.ldvSales, thirdYear.ldvSales);
+      } else {
+        setFirstYear({...firstYear, ldvSales: parseInt(value)});
+        averageLdvSales(parseInt(value), secondYear.ldvSales, thirdYear.ldvSales);
+      }
+    }
+    if (id === 'second') {
+      if (value === '') {
+        setSecondYear({ ...secondYear, ldvSales: 0 });
+        averageLdvSales(firstYear.ldvSales, 0, thirdYear.ldvSales);
+      } else {
+        setSecondYear({...secondYear, ldvSales: parseInt(value)});
+        averageLdvSales(firstYear.ldvSales, parseInt(value), thirdYear.ldvSales);
+      }
+    }
+    if (id === 'third') {
+      if (value === '') {
+        setSecondYear({ ...thirdYear, ldvSales: 0 });
+        averageLdvSales(firstYear.ldvSales, secondYear.ldvSales, 0);
+      } else {
+        setThirdYear({...thirdYear, ldvSales: parseInt(value)});
+        averageLdvSales(firstYear.ldvSales, secondYear.ldvSales, parseInt(value));
+      }
+    }
+  };
+
+  const averageLdvSales = (firstYear, secondYear, thirdYear) => {
+    let avg = 0;
+    avg = (firstYear + secondYear + thirdYear) / 3;
+    setAvgSales(Math.round(avg));
   };
 
   const handleChange = (event) => {
@@ -64,20 +103,20 @@ const ConsumerSalesContainer = (props) => {
   };
 
   const handleSave = () => {
+    const previousSalesInfo = [firstYear, secondYear, thirdYear];
     if (!salesInput) {
       setError(true);
     } else {
       setError(false);
-      axios
-        .post(ROUTES_COMPLIANCE.VEHICLES, {
+      axios.post(ROUTES_COMPLIANCE.VEHICLES, {
           data: vehicles,
           ldvSales: salesInput,
           modelYearReportId: id,
-          previousSales: previousSales,
-          confirmation: checkboxes
+          previousSales: previousSalesInfo,
+          confirmation: checkboxes,
         })
         .then(() => {
-          setConfirmed(true)
+          setConfirmed(true);
           setDisabledCheckboxes('disabled');
           setReadOnly(true);
         })
@@ -92,6 +131,7 @@ const ConsumerSalesContainer = (props) => {
 
   useEffect(() => {
     refreshDetails(true);
+    averageLdvSales(firstYear.ldvSales, secondYear.ldvSales, thirdYear.ldvSales);
   }, [keycloak.authenticated]);
 
   return (
@@ -108,13 +148,14 @@ const ConsumerSalesContainer = (props) => {
         handleChange={handleChange}
         vehicles={vehicles}
         confirmed={confirmed}
-        previousSales={previousSales}
         error={error}
         readOnly={readOnly}
         assertions={assertions}
         checkboxes={checkboxes}
         disabledCheckboxes={disabledCheckboxes}
         handleCheckboxClick={handleCheckboxClick}
+        handleInputChange={handleInputChange}
+        avgSales={avgSales}
       />
     </>
   );

--- a/frontend/src/compliance/SupplierInformationContainer.js
+++ b/frontend/src/compliance/SupplierInformationContainer.js
@@ -80,8 +80,8 @@ const SupplierInformationContainer = (props) => {
       setLoading(false);
     });
     axios.get(ROUTES_SIGNING_AUTHORITY_ASSERTIONS.LIST).then((response) => {
-      const filteredAsserstions = response.data.filter((data) => data.module == 'supplier_information');
-      setAssertions(filteredAsserstions);
+      const filteredAssertions = response.data.filter((data) => data.module === 'supplier_information');
+      setAssertions(filteredAssertions);
     });
   };
 

--- a/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
+++ b/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import CustomPropTypes from '../../app/utilities/props';
 import Loading from '../../app/components/Loading';
 import ComplianceReportAlert from './ComplianceReportAlert';
 import Button from '../../app/components/Button';
 import { now } from 'moment';
+import history from '../../app/History';
 import ComplianceReportSignOff from './ComplianceReportSignOff';
 import ConsumerSalesLDVModalTable from '../components/ConsumerSalesLDVModelTable';
 
@@ -16,13 +17,14 @@ const ConsumerSalesDetailsPage = (props) => {
     handleChange,
     vehicles,
     confirmed,
-    previousSales,
     assertions,
     checkboxes,
     readOnly,
     disabledCheckboxes,
     error,
     handleCheckboxClick,
+    handleInputChange,
+    avgSales,
   } = props;
 
   const details = {
@@ -41,6 +43,24 @@ const ConsumerSalesDetailsPage = (props) => {
 
   if (loading) {
     return <Loading />;
+  }
+
+  const vehicleSupplierClass = (avg) => {
+    let supplierClass = "";
+    let text = "";
+    if (avg < 1000) {
+      supplierClass = "Small Volume Supplier";
+      text = "(under 1,000 total LDV sales)";
+    }
+    else if (avg < 5000) {
+      supplierClass = "Medium Volume Supplier";
+      text = "(under 5,000 total LDV sales)";
+    }
+    else if (avg > 5000) {
+      supplierClass = "Large Volume Supplier";
+      text = "(over 5,000 total LDV sales)";
+    }
+    return [supplierClass, text];
   }
 
   return (
@@ -78,46 +98,107 @@ const ConsumerSalesDetailsPage = (props) => {
                   </label>
                   <input
                     className="textbox-sales"
-                    type="text"
+                    type="number"
                     onChange={handleChange}
                     readOnly={readOnly}
+                    min="0"
                   ></input>
                   {error && (
-                    <span className="text-danger ml-2">
+                    <small className="text-danger ml-2">
                       2020 Model Year LDV Sales\Leases can't be blank
-                    </span>
+                    </small>
                   )}
                 </form>
               </div>
             </div>
             <div className="confirm-previous-sales mt-2">
               <div className="text-blue">
-                Confirm the previous 3 model year light duty vehicle sales and
+                Enter the previous 3 model year light duty vehicle sales and
                 lease total (ICE & ZEV) in British Columbia for{' '}
-                {details.organization.name}.
+                {details.organization.name}. If this is your first year
+                supplying light duty vehicles in B.C. you can enter 0 in the
+                input fields.
               </div>
-              <div className="previous-ldv-sales mt-2 p-3">
-                {previousSales.map((yearSale) => (
-                  <div className="model-year-ldv" key={yearSale.id}>
-                    <label className="text-blue mr-4 font-weight-bold">
-                      {yearSale.modelYear} Model Year LDV Sales\Leases:
-                    </label>
-                    <label className="sales-numbers">{yearSale.ldvSales}</label>
+              <div className="row">
+                <div className="col-6">
+                  <div className="previous-ldv-sales mt-2 p-3">
+                    <form onSubmit={(event) => handleSave(event)}>
+                      <label className="text-blue mr-4 font-weight-bold">
+                        2019 Model Year LDV Sales\Leases
+                      </label>
+                      <input
+                        className="textbox-first"
+                        type="number"
+                        onChange={handleInputChange}
+                        id="first"
+                        min="0"
+                      ></input>
+                      <label className="text-blue mr-4 font-weight-bold">
+                        2018 Model Year LDV Sales\Leases
+                      </label>
+                      <input
+                        className="textbox-second"
+                        type="number"
+                        onChange={handleInputChange}
+                        id="second"
+                        min="0"
+                      ></input>
+                      <label className="text-blue mr-4 font-weight-bold">
+                        2017 Model Year LDV Sales\Leases
+                      </label>
+                      <input
+                        className="textbox-third"
+                        type="number"
+                        onChange={handleInputChange}
+                        id="third"
+                        min="0"
+                      ></input>
+                    </form>
                   </div>
-                ))}
+                </div>
+                <div className="offset-1 col-5">
+                  <div className="previous-ldv-avg p-3 mt-2">
+                    <div className="mt-1 row">
+                      <h4 className="col-5 ml-2">3 Year Average LDV Sales:</h4>
+                      <div className="col-5">
+                        <span>{avgSales}</span>
+                      </div>
+                    </div>
+                    <div className="mt-1 row">
+                      <h4 className="col-5 ml-2">Vehicle Supplier Class: </h4>
+                      <div className="col-5">
+                        <span> {vehicleSupplierClass(avgSales)[0]} </span>
+                        <span> {vehicleSupplierClass(avgSales)[1]} </span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div className="ldv-zev-models mt-2">
-                <label className="text-blue mr-4 font-weight-bold">
-                  Consumer Sales of Zero-Emission Vehicles
-                </label>
-                <div className="sales-table mt-2">
-                  <ConsumerSalesLDVModalTable vehicles={vehicles} />
-                </div>
-                <div className="total-ldv-sales text-blue mt-2">
-                  Pending Sales are VIN applied for in credit applications
-                  awaiting government review. Sales Issued are those VIN already
-                  verified by government as being eligible to earn credits
-                </div>
+            </div>
+            <div className="ldv-zev-models mt-2">
+              <label className="text-blue mr-4 font-weight-bold">
+                Consumer Sales of Zero-Emission Vehicles
+              </label>
+              <div className="text-blue mt-2">
+                If you have outstanding 2020 consumer sales to submit you can{' '}
+                <label
+                  className="text-primary"
+                  onClick={() => {
+                    history.push('/credit-requests/new');
+                  }}
+                >
+                  {' '}
+                  <u>enter an application for credits for consumer sales</u>
+                </label>{' '}
+                as part of this model year report.
+              </div>
+              <div className="sales-table mt-2">
+                <ConsumerSalesLDVModalTable vehicles={vehicles} />
+              </div>
+              <div className="total-ldv-sales text-blue mt-2">
+                Pending Sales are VIN applied for in credit applications
+                awaiting government review. Sales Issued are those VIN already
+                verified by government as being eligible to earn credits
               </div>
             </div>
           </div>
@@ -159,6 +240,9 @@ const ConsumerSalesDetailsPage = (props) => {
     </div>
   );
 };
+ConsumerSalesDetailsPage.defaultProps = {
+  avgSales: 0,
+};
 ConsumerSalesDetailsPage.propTypes = {
   user: CustomPropTypes.user.isRequired,
   loading: PropTypes.bool.isRequired,
@@ -166,12 +250,15 @@ ConsumerSalesDetailsPage.propTypes = {
   handleChange: PropTypes.func.isRequired,
   vehicles: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   confirmed: PropTypes.bool.isRequired,
-  previousSales: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   error: PropTypes.bool.isRequired,
   assertions: PropTypes.arrayOf(PropTypes.shape()),
-  checkboxes: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.number, PropTypes.string])),
+  checkboxes: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ),
   handleCheckboxClick: PropTypes.func.isRequired,
   disabledCheckboxes: PropTypes.string.isRequired,
-  readOnly: PropTypes.bool.isRequired
+  readOnly: PropTypes.bool.isRequired,
+  handleInputChange: PropTypes.func.isRequired,
+  avgSales: PropTypes.number.isRequired,
 };
 export default ConsumerSalesDetailsPage;

--- a/frontend/src/compliance/components/SupplierInformationDetailsPage.js
+++ b/frontend/src/compliance/components/SupplierInformationDetailsPage.js
@@ -61,10 +61,6 @@ const SupplierInformationDetailsPage = (props) => {
               <h4 className="d-inline">Legal Name: </h4>
               <span> {details.organization.name} </span>
             </div>
-            <div className="mt-3">
-              <h4 className="d-inline">Vehicle Supplier Class: </h4>
-              <span> Large Volume Supplier </span>
-            </div>
             <div>
               <div className="d-inline-block mr-5 mt-3">
                 <h4>Service Address</h4>


### PR DESCRIPTION
-Added input boxes for previous year sale instead of labels.
-saving input values to the DB.
-calculating average of 3 previous year values and supplier class based on the average.