### PR TITLE
 ZEVA-498:Consumer Sales page - Retrieve values from the saved snapshot

### DIFF
--- a/backend/api/serializers/model_year_report_previous_sales.py
+++ b/backend/api/serializers/model_year_report_previous_sales.py
@@ -1,16 +1,21 @@
-from rest_framework.serializers import ModelSerializer
+from rest_framework.serializers import ModelSerializer, SlugRelatedField
 from api.serializers.model_year_report import ModelYearReportSerializer
 from api.serializers.vehicle import ModelYearSerializer
+from api.models.model_year import ModelYear
 
-from api.models.model_year_report_previous_sales import ModelYearReportPreviousSales
+from api.models.model_year_report_previous_sales import \
+     ModelYearReportPreviousSales
 
 
-class ModelYearReportPreviousSalesSerializer(ModelSerializer):  
-    model_year = ModelYearSerializer()
+class ModelYearReportPreviousSalesSerializer(ModelSerializer):
+    model_year = SlugRelatedField(
+        slug_field='name',
+        queryset=ModelYear.objects.all()
+    )
     model_year_report = ModelYearReportSerializer
 
     class Meta:
         model = ModelYearReportPreviousSales
         fields = (
-            'id', 'previous_sales', 'model_year', 'model_year_report',
+            'id', 'previous_sales', 'model_year',
         )

--- a/backend/api/serializers/model_year_report_vehicle.py
+++ b/backend/api/serializers/model_year_report_vehicle.py
@@ -9,16 +9,28 @@ from api.models.model_year import ModelYear
 from api.models.model_year_report import ModelYearReport
 from api.models.credit_class import CreditClass
 
+
 class ModelYearReportVehicleSerializer(ModelSerializer):
-    zev_class = CreditClassSerializer(read_only=True)
-    model_year = ModelYearSerializer(read_only=True)
-    zev_type = VehicleZevTypeSerializer(read_only=True)
-    
+    zev_class = SlugRelatedField(
+        slug_field='credit_class',
+        queryset=CreditClass.objects.all()
+    )
+    model_year = SlugRelatedField(
+        slug_field='name',
+        queryset=ModelYear.objects.all()
+    )
+    vehicle_zev_type = SlugRelatedField(
+        slug_field='vehicle_zev_code',
+        queryset=ZevType.objects.all()
+    )
+
     class Meta:
         model = ModelYearReportVehicle
         fields = (
-            'id', 'pending_sales', 'sales_issued', 'make', 'model_name', 'range', 'zev_class', 'model_year', 'vehicle_zev_type','model_year_report'
+            'id', 'pending_sales', 'sales_issued', 'make', 'model_name',
+            'range', 'zev_class', 'model_year', 'vehicle_zev_type',
         )
+
 
 class ModelYearReportVehicleSaveSerializer(ModelSerializer):
     """
@@ -50,5 +62,7 @@ class ModelYearReportVehicleSaveSerializer(ModelSerializer):
     class Meta:
         model = ModelYearReportVehicle
         fields = (
-            'pending_sales', 'sales_issued', 'make', 'model_name', 'range', 'zev_class', 'model_year', 'vehicle_zev_type', 'model_year_report_id'
+            'pending_sales', 'sales_issued', 'make', 'model_name', 'range',
+            'zev_class', 'model_year', 'vehicle_zev_type',
+            'model_year_report_id'
         )

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -47,7 +47,7 @@ router.register(
     r'uploads', UploadViewSet, basename='minio'
 )
 router.register(
-    r'compliance/vehicle', ModelYearReportConsumerSalesViewSet, basename='consumer-sales'
+    r'compliance/consumer-sales', ModelYearReportConsumerSalesViewSet, basename='consumer-sales'
 )
 router.register(
     r'compliance/compliance-activity-details', ComplianceObligationActivityViewset, basename='details'

--- a/backend/api/viewsets/model_year_report_consumer_sales.py
+++ b/backend/api/viewsets/model_year_report_consumer_sales.py
@@ -160,26 +160,3 @@ class ModelYearReportConsumerSalesViewSet(mixins.ListModelMixin,
             'organization_name': request.user.organization.name,
             'validation_status': report.validation_status.value,
             })
-
-    @action(detail=True)
-    def previouse_sales(self, request, **kwargs):
-        model_year_report_id = kwargs.pop('pk')
-        queryset = ModelYearReportPreviousSales.objects.filter(
-            model_year_report_id=model_year_report_id)
-        serializer = ModelYearReportPreviousSalesSerializer(queryset, many=True)
-        return Response(serializer.data)
-
-    @action(detail=True)
-    def vehicles(self, request, **kwargs):
-        model_year_report_id = kwargs.pop('pk')
-        queryset = ModelYearReportVehicle.objects.filter(
-            model_year_report_id=model_year_report_id)
-        serializer = ModelYearReportVehicleSerializer(queryset, many=True)
-        return Response(serializer.data)
-
-    @action(detail=True)
-    def ldv_sales(self, request, **kwargs):
-        model_year_report_id = kwargs.pop('pk')
-        ldv_sales = ModelYearReport.objects.values_list('ldv_sales', flat=True).get(
-            id=model_year_report_id)
-        return Response({'ldv_sales': ldv_sales})

--- a/backend/api/viewsets/model_year_report_consumer_sales.py
+++ b/backend/api/viewsets/model_year_report_consumer_sales.py
@@ -123,13 +123,14 @@ class ModelYearReportConsumerSalesViewSet(mixins.ListModelMixin,
         report = get_object_or_404(queryset, pk=pk)
 
         previous_sales = ModelYearReportPreviousSales.objects.filter(
-            model_year_report_id=report.id)
+            model_year_report_id=report.id).order_by('-model_year__name')
         previous_sales_serializer = ModelYearReportPreviousSalesSerializer(
             previous_sales, many=True)
 
         vehicle = ModelYearReportVehicle.objects.filter(
             model_year_report_id=report.id)
-        vehicles_serializer = ModelYearReportVehicleSerializer(vehicle, many=True)
+        vehicles_serializer = ModelYearReportVehicleSerializer(
+            vehicle, many=True)
 
         ldv_sales = ModelYearReport.objects.values_list(
             'ldv_sales', flat=True).get(

--- a/backend/api/viewsets/model_year_report_consumer_sales.py
+++ b/backend/api/viewsets/model_year_report_consumer_sales.py
@@ -53,7 +53,7 @@ class ModelYearReportConsumerSalesViewSet(mixins.ListModelMixin,
         previous_sales = request.data.get('previous_sales')
         confirmations = request.data.get('confirmation')
         supplier_class = request.data.get('supplier_class')
-        previouse_years_exist = request.data.get('previous_years_exist')
+        previous_years_exist = request.data.get('previous_years_exist')
 
         report = ModelYearReport.objects.get(id=model_year_report_id)
 
@@ -85,7 +85,7 @@ class ModelYearReportConsumerSalesViewSet(mixins.ListModelMixin,
         """
         Save previous years LDV sales information
         """
-        if not previouse_years_exist:
+        if not previous_years_exist:
             for previous_sale in previous_sales:
                 model_year_report_previous_sale = ModelYearReportPreviousSales.objects.create(
                     previous_sales=previous_sale.get('ldv_sales'),

--- a/backend/api/viewsets/model_year_report_consumer_sales.py
+++ b/backend/api/viewsets/model_year_report_consumer_sales.py
@@ -122,9 +122,6 @@ class ModelYearReportConsumerSalesViewSet(mixins.ListModelMixin,
         queryset = self.get_queryset()
         report = get_object_or_404(queryset, pk=pk)
 
-        organization = OrganizationSerializer(
-                request.user.organization)
-
         previous_sales = ModelYearReportPreviousSales.objects.filter(
             model_year_report_id=report.id)
         previous_sales_serializer = ModelYearReportPreviousSalesSerializer(
@@ -153,7 +150,7 @@ class ModelYearReportConsumerSalesViewSet(mixins.ListModelMixin,
 
         return Response({
             'previous_sales': previous_sales_serializer.data,
-            'vehicles': vehicles_serializer.data,
+            'vehicle_list': vehicles_serializer.data,
             'ldv_sales': ldv_sales,
             'model_year_report_history': history.data,
             'confirmations': confirmations,

--- a/frontend/src/app/css/ComplianceReport.scss
+++ b/frontend/src/app/css/ComplianceReport.scss
@@ -28,17 +28,18 @@
   .consumer-sales {
     border: 1px solid $border-grey;
   }
+  .previous-ldv-sales,
   .previous-ldv-avg {
     border: 1px solid $border-grey;
-    height: 94%;
+    background-color: $default-background-grey;
+    height: 100%;
   }
   .textbox-first,
   .textbox-second,
   .textbox-third{
     width: 30%;
   }
-  .ldv-sales,
-  .previous-ldv-sales {
+  .ldv-sales{
     background-color: $default-background-grey;
   }
   .textbox-sales {

--- a/frontend/src/app/routes/Compliance.js
+++ b/frontend/src/app/routes/Compliance.js
@@ -12,7 +12,8 @@ const COMPLIANCE = {
   REPORT_CREDIT_ACTIVITY: `${API_BASE_PATH}/reports/:id/credit-activity`,
   REPORT_SUMMARY: `${API_BASE_PATH}/reports/:id/summary`,
   REPORT_ASSESSMENT: `${API_BASE_PATH}/reports/:id/assessment`,
-  VEHICLES: `${API_BASE_PATH}/vehicle`,
+  CONSUMER_SALES: `${API_BASE_PATH}/consumer-sales`,
+  RETRIEVE_CONSUMER_SALES: `${API_BASE_PATH}/consumer-sales/:id`,
   REPORT_DETAILS_BY_YEAR: `${API_BASE_PATH}/compliance-activity-details/:year`,
 };
 

--- a/frontend/src/compliance/ConsumerSalesContainer.js
+++ b/frontend/src/compliance/ConsumerSalesContainer.js
@@ -45,7 +45,7 @@ const ConsumerSalesContainer = (props) => {
       .then((response) => {
         const {
           previousSales,
-          vehicles,
+          vehicleList,
           confirmations,
           organizationName,
           ldvSales,
@@ -61,8 +61,8 @@ const ConsumerSalesContainer = (props) => {
             parseInt(previousSales[2].previousSales)
           );
         }
-        if (vehicles.length > 0) {
-          setVehicles(vehicles);
+        if (vehicleList.length > 0) {
+          setVehicles(vehicleList);
         } else {
           axios.get(ROUTES_VEHICLES.VEHICLES_SALES).then((response) => {
             setVehicles(response.data);
@@ -89,7 +89,7 @@ const ConsumerSalesContainer = (props) => {
         
     });
 
-    const assertions = axios.get(ROUTES_SIGNING_AUTHORITY_ASSERTIONS.LIST)
+    const assertionList = axios.get(ROUTES_SIGNING_AUTHORITY_ASSERTIONS.LIST)
       .then((response) => {
         const filteredAssertions = response.data.filter(
           (data) => data.module === 'consumer_sales'
@@ -97,7 +97,7 @@ const ConsumerSalesContainer = (props) => {
         setAssertions(filteredAssertions);
       });
 
-    Promise.all([consumerSalesData, assertions]).then(() => {
+    Promise.all([consumerSalesData, assertionList]).then(() => {
       setLoading(false);
     });
   };
@@ -200,7 +200,7 @@ const ConsumerSalesContainer = (props) => {
         })
         .then(() => {
           setConfirmed(true);
-          //setDisabledCheckboxes('disabled');
+          setDisabledCheckboxes('disabled');
         })
         .catch((error) => {
           const { response } = error;

--- a/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
+++ b/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
@@ -11,6 +11,7 @@ import ConsumerSalesLDVModalTable from './ConsumerSalesLDVModelTable';
 
 const ConsumerSalesDetailsPage = (props) => {
   const {
+    details,
     user,
     loading,
     handleSave,
@@ -19,32 +20,39 @@ const ConsumerSalesDetailsPage = (props) => {
     confirmed,
     assertions,
     checkboxes,
-    readOnly,
     disabledCheckboxes,
     error,
     handleCheckboxClick,
     handleInputChange,
     avgSales,
     vehicleSupplierClass,
+    previousYearsExist,
+    previousYearsList,
+    salesInput,
   } = props;
 
-  const details = {
-    consumerSales: {
-      history: [
-        {
-          status: 'DRAFT',
-          createTimestamp: now(),
-          createUser: user,
-        },
-      ],
-      status: 'DRAFT',
-    },
-    organization: user.organization,
-  };
 
   if (loading) {
     return <Loading />;
   }
+
+  const confirmPreviousSalesText = (
+    <div className="text-blue">
+      Confirm the previous 3 model year light duty vehicle sales and lease
+      totals (ICE & ZEV) in British Columbia for {details.organization.name}.
+      These totals are taken from previous model year reports, changes required
+      to these totals will require a supplemental report
+    </div>
+  );
+
+  const enterPreviousSalesText = (
+    <div className="text-blue">
+      Enter the previous 3 model year light duty vehicle sales and lease total
+      (ICE & ZEV) in British Columbia for {details.organization.name}. If this
+      is your first year supplying light duty vehicles in B.C. you can enter 0
+      in the input fields.
+    </div>
+  );
 
   return (
     <div id="compliance-consumer-sales-details" className="page">
@@ -53,16 +61,14 @@ const ConsumerSalesDetailsPage = (props) => {
           <h2>2020 Model Year Report</h2>
         </div>
       </div>
-      {confirmed && (
         <div className="row">
           <div className="col-12">
-            <ComplianceReportAlert
-              report={details.consumerSales}
-              type="Consumer Sales"
-            />
+            {confirmed && (
+              <ComplianceReportAlert report={details.consumerSales} type="Consumer Sales" />
+            )}
           </div>
         </div>
-      )}
+    
       <div className="row mt-1">
         <div className="col-12">
           <div className="p-3 consumer-sales">
@@ -80,10 +86,10 @@ const ConsumerSalesDetailsPage = (props) => {
                     2020 Model Year LDV Sales\Leases
                   </label>
                   <input
+                    defaultValue={salesInput ? salesInput : 0}
                     className="textbox-sales"
                     type="number"
                     onChange={handleChange}
-                    readOnly={readOnly}
                     min="0"
                   />
                   {error && (
@@ -94,71 +100,86 @@ const ConsumerSalesDetailsPage = (props) => {
                 </form>
               </div>
             </div>
-            <div className="confirm-previous-sales mt-2">
-              <div className="text-blue">
-                Enter the previous 3 model year light duty vehicle sales and
-                lease total (ICE & ZEV) in British Columbia for{' '}
-                {details.organization.name}. If this is your first year
-                supplying light duty vehicles in B.C. you can enter 0 in the
-                input fields.
-              </div>
-              <div className="row">
-                <div className="col-6">
+            <div className="row">
+              {previousYearsExist ? (
+                <div className="col-sm-12">{confirmPreviousSalesText}</div>
+              ) : (
+                <div className="col-sm-12">{enterPreviousSalesText}</div>
+              )}
+            </div>
+            <div className="row">
+              <div className="col-6">
+                {previousYearsExist ? (
                   <div className="previous-ldv-sales mt-2 p-3">
-                    <form onSubmit={(event) => handleSave(event)}>
-                      <div className="row ml-1 mb-2">
+                    {previousYearsList.map((yearSale) => (
+                      <div className="model-year-ldv" key={yearSale.id}>
                         <label className="text-blue mr-4 font-weight-bold">
-                          2019 Model Year LDV Sales\Leases
+                          {yearSale.modelYear} Model Year LDV Sales\Leases:
                         </label>
-                        <input
-                          className="textbox-first"
-                          type="number"
-                          onChange={handleInputChange}
-                          id="first"
-                          min="0"
-                        />
-                      </div>
-                      <div className="row ml-1 mb-2">
-                        <label className="text-blue mr-4 font-weight-bold">
-                          2018 Model Year LDV Sales\Leases
+                        <label className="sales-numbers">
+                          {yearSale.previousSales}
                         </label>
-                        <input
-                          className="textbox-second"
-                          type="number"
-                          onChange={handleInputChange}
-                          id="second"
-                          min="0"
-                        />
                       </div>
-                      <div className="row ml-1 mb-2">
-                        <label className="text-blue mr-4 font-weight-bold">
-                          2017 Model Year LDV Sales\Leases
-                        </label>
-                        <input
-                          className="textbox-third"
-                          type="number"
-                          onChange={handleInputChange}
-                          id="third"
-                          min="0"
-                        />
-                      </div>
-                    </form>
+                    ))}
                   </div>
-                </div>
-                <div className="offset-1 col-5">
-                  <div className="previous-ldv-avg p-3 mt-2">
-                    <div className="mt-1 row">
-                      <h4 className="col-5 ml-2">3 Year Average LDV Sales:</h4>
-                      <div className="col-5">
-                        <span>{avgSales}</span>
-                      </div>
+                ) : (
+                  <div className="confirm-previous-sales mt-2">
+                    <div className="previous-ldv-sales mt-2 p-3">
+                      <form onSubmit={(event) => handleSave(event)}>
+                        <div className="row ml-1 mb-2">
+                          <label className="text-blue mr-4 font-weight-bold">
+                            2019 Model Year LDV Sales\Leases
+                          </label>
+                          <input
+                            className="textbox-first"
+                            type="number"
+                            onChange={handleInputChange}
+                            id="first"
+                            min="0"
+                          />
+                        </div>
+                        <div className="row ml-1 mb-2">
+                          <label className="text-blue mr-4 font-weight-bold">
+                            2018 Model Year LDV Sales\Leases
+                          </label>
+                          <input
+                            className="textbox-second"
+                            type="number"
+                            onChange={handleInputChange}
+                            id="second"
+                            min="0"
+                          />
+                        </div>
+                        <div className="row ml-1 mb-2">
+                          <label className="text-blue mr-4 font-weight-bold">
+                            2017 Model Year LDV Sales\Leases
+                          </label>
+                          <input
+                            className="textbox-third"
+                            type="number"
+                            onChange={handleInputChange}
+                            id="third"
+                            min="0"
+                          />
+                        </div>
+                      </form>
                     </div>
-                    <div className="mt-1 row">
-                      <h4 className="col-5 ml-2">Vehicle Supplier Class: </h4>
-                      <div className="col-5">
-                        <span> {vehicleSupplierClass(avgSales)[0]} </span>
-                        <span> {vehicleSupplierClass(avgSales)[1]} </span>
-                      </div>
+                  </div>
+                )}
+              </div>
+              <div className="col-6">
+                <div className="previous-ldv-avg p-3 mt-2">
+                  <div className="mt-1 row">
+                    <h4 className="col-5 ml-2">3 Year Average LDV Sales:</h4>
+                    <div className="col-5">
+                      <span>{avgSales}</span>
+                    </div>
+                  </div>
+                  <div className="mt-1 row">
+                    <h4 className="col-5 ml-2">Vehicle Supplier Class: </h4>
+                    <div className="col-5">
+                      <span> {vehicleSupplierClass(avgSales)[0]} </span>
+                      <span> {vehicleSupplierClass(avgSales)[1]} </span>
                     </div>
                   </div>
                 </div>
@@ -201,7 +222,6 @@ const ConsumerSalesDetailsPage = (props) => {
             handleCheckboxClick={handleCheckboxClick}
             disabledCheckboxes={disabledCheckboxes}
             user={user}
-            readOnly={readOnly}
           />
         </div>
       </div>
@@ -233,6 +253,10 @@ ConsumerSalesDetailsPage.defaultProps = {
   avgSales: 0,
 };
 ConsumerSalesDetailsPage.propTypes = {
+  details: PropTypes.shape({
+    organization: PropTypes.shape(),
+    consumerSales: PropTypes.shape(),
+  }).isRequired,
   user: CustomPropTypes.user.isRequired,
   loading: PropTypes.bool.isRequired,
   handleSave: PropTypes.func.isRequired,
@@ -242,13 +266,15 @@ ConsumerSalesDetailsPage.propTypes = {
   error: PropTypes.bool.isRequired,
   assertions: PropTypes.arrayOf(PropTypes.shape()),
   checkboxes: PropTypes.arrayOf(
-    PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
   ),
   handleCheckboxClick: PropTypes.func.isRequired,
   disabledCheckboxes: PropTypes.string.isRequired,
-  readOnly: PropTypes.bool.isRequired,
   handleInputChange: PropTypes.func.isRequired,
   avgSales: PropTypes.number.isRequired,
   vehicleSupplierClass: PropTypes.func.isRequired,
+  previousYearsExist: PropTypes.bool.isRequired,
+  previousYearsList: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+  salesInput: PropTypes.number,
 };
 export default ConsumerSalesDetailsPage;


### PR DESCRIPTION
* Based on the report id, load the snapshots of previous_sales, vehicle_list, ldv_sales and confirmation if it exist in the DB, 
   else load vehicle_list from vehicle_sales, and display input boxes for previous sales & ldv_sales. 
* Made some minor name changes and formatting
