### PR TITLE
ZEVA 502- retrieve values for summary page

### DIFF
--- a/backend/api/viewsets/model_year_report_compliance_obligation.py
+++ b/backend/api/viewsets/model_year_report_compliance_obligation.py
@@ -81,16 +81,13 @@ class ModelYearReportComplianceObligationViewset(
             compliance_obj.save()
         return Response(id)
 
-    @action(detail=False, url_path=r'(?P<year>\d+)')
+    @action(detail=False, url_path=r'(?P<id>\d+)')
     @method_decorator(permission_required('VIEW_SALES'))
     def details(self, request, *args, **kwargs):
         organization = request.user.organization
-        year_kwarg = kwargs.get('year')
-        model_year = ModelYear.objects.get(
-            name=year_kwarg,
-        )
+        id = kwargs.get('id')
         report = ModelYearReport.objects.get(
-            model_year_id=model_year.id
+            id=id
         )
         snapshot = ModelYearReportComplianceObligation.objects.filter(
             model_year_report_id=report.id,

--- a/frontend/src/app/css/App.scss
+++ b/frontend/src/app/css/App.scss
@@ -300,6 +300,9 @@ p {
     color: rgba(26, 90, 150, 0.5);
   }
 }
+.text-black {
+  color: $default-text-black
+}
 
 .well {
   background-color: $default-background-grey;

--- a/frontend/src/app/routes/Compliance.js
+++ b/frontend/src/app/routes/Compliance.js
@@ -15,7 +15,7 @@ const COMPLIANCE = {
   OBLIGATION: `${API_BASE_PATH}/compliance-activity-details`,
   CONSUMER_SALES: `${API_BASE_PATH}/consumer-sales`,
   RETRIEVE_CONSUMER_SALES: `${API_BASE_PATH}/consumer-sales/:id`,
-  REPORT_DETAILS_BY_YEAR: `${API_BASE_PATH}/compliance-activity-details/:year`,
+  REPORT_COMPLIANCE_DETAILS_BY_ID: `${API_BASE_PATH}/compliance-activity-details/:id`,
   REPORT_SUBMISSION: `${API_BASE_PATH}/reports/submission`,
 };
 

--- a/frontend/src/compliance/ComplianceObligationContainer.js
+++ b/frontend/src/compliance/ComplianceObligationContainer.js
@@ -129,8 +129,8 @@ const ComplianceObligationContainer = (props) => {
         setRatios(filteredRatio);
       });
 
-      const complianceReportDetails = axios.get(ROUTES_COMPLIANCE.REPORT_DETAILS_BY_YEAR
-        .replace(':year', reportDetailsResponse.modelYear.name)).then((complianceResponse) => {
+      const complianceReportDetails = axios.get(ROUTES_COMPLIANCE.REPORT_COMPLIANCE_DETAILS_BY_ID
+        .replace(':id', id)).then((complianceResponse) => {
         const yearObject = {};
         const complianceResponseDetails = complianceResponse.data;
         if (!complianceResponseDetails.reportYearTransactions) {

--- a/frontend/src/compliance/ComplianceReportSummaryContainer.js
+++ b/frontend/src/compliance/ComplianceReportSummaryContainer.js
@@ -153,8 +153,13 @@ const ComplianceReportSummaryContainer = (props) => {
       axios.get(ROUTES_COMPLIANCE.RATIOS),
       axios.get(ROUTES_VEHICLES.VEHICLES_SALES),
       axios.get(ROUTES_COMPLIANCE.RETRIEVE_CONSUMER_SALES.replace(':id', id)),
+      axios.get(ROUTES_COMPLIANCE.REPORT_COMPLIANCE_DETAILS_BY_ID.replace(':id', id)),
     ]).then(axios.spread((
-      reportDetailsResponse, allComplianceRatiosResponse, vehicleSalesResponse, consumerSalesResponse,
+      reportDetailsResponse,
+      allComplianceRatiosResponse,
+      vehicleSalesResponse,
+      consumerSalesResponse,
+      creditActivityResponse,
     ) => {
       // SUPPLIER INFORMATION
       const {
@@ -202,9 +207,6 @@ const ComplianceReportSummaryContainer = (props) => {
         averageLdv3Years += parseFloat(each.previousSales);
       });
       averageLdv3Years = formatNumeric((averageLdv3Years / 3), 2);
-      // console.log(consumerSalesResponse.data);
-      // console.log(reportDetailsResponse.data);
-      // console.log(vehicleSalesResponse.data);
       setConsumerSalesDetails({
         ...consumerSalesDetails,
         pendingZevSales,
@@ -216,6 +218,8 @@ const ComplianceReportSummaryContainer = (props) => {
       });
       setComplianceRatios(allComplianceRatiosResponse.data
         .filter((each) => each.modelYear === year));
+      // CREDIT ACTIVITY
+      console.log(creditActivityResponse.data)
       setLoading(false);
     }));
   };

--- a/frontend/src/compliance/ComplianceReportSummaryContainer.js
+++ b/frontend/src/compliance/ComplianceReportSummaryContainer.js
@@ -2,8 +2,8 @@ import axios from 'axios';
 import { now } from 'moment';
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import Loading from '../app/components/Loading';
 import { useParams } from 'react-router-dom';
+import Loading from '../app/components/Loading';
 import ROUTES_COMPLIANCE from '../app/routes/Compliance';
 import CustomPropTypes from '../app/utilities/props';
 import ComplianceReportTabs from './components/ComplianceReportTabs';
@@ -20,7 +20,8 @@ const ComplianceReportSummaryContainer = (props) => {
   const [complianceRatios, setComplianceRatios] = useState({});
   const [supplierDetails, setSupplierDetails] = useState({});
   const [makes, setMakes] = useState({});
-  const [creditActivityDetails, setCreditActivityDetails] = useState({})
+  const [confirmationStatuses, setConfirmationStatuses] = useState({});
+  const [creditActivityDetails, setCreditActivityDetails] = useState({});
   const [assertions, setAssertions] = useState([{ id: 0, description: 'On behalf of [insert supplier name], I confirm the information included in this Model Year report is complete and accurate' }]);
   const handleCheckboxClick = (event) => {
     if (!event.target.checked) {
@@ -66,8 +67,8 @@ const ComplianceReportSummaryContainer = (props) => {
       consumerSalesResponse,
       creditActivityResponse,
     ) => {
-      // SUPPLIER INFORMATION
       const {
+        statuses,
         makes: modelYearReportMakes,
         modelYearReportAddresses,
         modelYearReportHistory,
@@ -76,9 +77,12 @@ const ComplianceReportSummaryContainer = (props) => {
         confirmations,
         modelYear: reportModelYear,
       } = reportDetailsResponse.data;
+      // ALL STATUSES
+      setConfirmationStatuses(statuses);
+
+      // SUPPLIER INFORMATION
       if (modelYearReportMakes) {
         const currentMakes = modelYearReportMakes.map((each) => (each.make));
-
         setMakes(currentMakes);
       }
       setSupplierDetails({
@@ -125,7 +129,7 @@ const ComplianceReportSummaryContainer = (props) => {
         .filter((each) => each.modelYear === year));
 
       // CREDIT ACTIVITY
-      let creditBalanceStart = { year: '', A: 0, B: 0 };
+      const creditBalanceStart = { year: '', A: 0, B: 0 };
       const creditBalanceEnd = { A: 0, B: 0 };
       const provisionalBalance = { A: 0, B: 0 };
       const pendingBalance = { A: 0, B: 0 };
@@ -218,6 +222,7 @@ const ComplianceReportSummaryContainer = (props) => {
         loading={loading}
         handleSubmit={handleSubmit}
         makes={makes}
+        confirmationStatuses={confirmationStatuses}
       />
 
     </>

--- a/frontend/src/compliance/ComplianceReportSummaryContainer.js
+++ b/frontend/src/compliance/ComplianceReportSummaryContainer.js
@@ -51,90 +51,6 @@ const ComplianceReportSummaryContainer = (props) => {
     reportSummary: 'draft',
     supplierInformation: '',
   };
-  // const creditsIssuedDetails = {
-  //   startingBalance: { A: 0, B: 0 },
-  //   endingBalance: { A: 1513.09, B: 191.29 },
-  //   creditsIssuedSales:
-  //     [
-  //       {
-  //         year: 2020,
-  //         A: 359.12,
-  //         B: 43.43,
-  //       },
-  //       {
-  //         year: 2019,
-  //         A: 1367.43,
-  //         B: 347.86,
-  //       },
-  //     ],
-  //   creditsIssuedInitiative:
-  //     [{
-  //       year: 2019,
-  //       A: 286.54,
-  //     }],
-  //   creditsIssuedPurchase: [
-  //     {
-  //       year: 2020,
-  //       A: 100.00,
-  //     },
-  //   ],
-  //   creditsTransferredIn: [
-  //     {
-  //       year: 2020,
-  //       A: 200.00,
-  //     },
-  //   ],
-  //   creditsTransferredAway: [
-  //     {
-  //       year: 2020,
-  //       A: -800.00,
-  //       B: -200.00,
-  //     },
-  //   ],
-  //   pendingSales: [
-  //     {
-  //       year: 2020,
-  //       A: 246.67,
-  //       B: 0,
-  //     },
-  //   ],
-  //   provisionalBalance: [
-  //     {
-  //       year: 2020,
-  //       A: 1192.33,
-  //       B: 43.43,
-  //     },
-  //     {
-  //       year: 2019,
-  //       A: 567.43,
-  //       B: 147.86,
-  //     },
-  //   ],
-  //   creditOffset: [
-  //     {
-  //       year: 2019,
-  //       A: -300,
-  //       B: -100,
-  //     },
-  //     {
-  //       year: 2020,
-  //       A: -458.71,
-  //       B: -91.29,
-  //     },
-  //   ],
-  //   provisionalAssessedBalance: [
-  //     {
-  //       year: 2019,
-  //       A: 754.38,
-  //       B: 0,
-  //     },
-  //     {
-  //       year: 2020,
-  //       A: 0,
-  //       B: 0,
-  //     },
-  //   ],
-  // };
   const refreshDetails = () => {
     setLoading(true);
     axios.all([
@@ -209,35 +125,55 @@ const ComplianceReportSummaryContainer = (props) => {
         .filter((each) => each.modelYear === year));
 
       // CREDIT ACTIVITY
-      const creditBalanceStart = {};
-      const creditBalanceEnd = {};
-      const provisionalBalance = {};
-      const pendingBalance = {};
-      const transfersIn = [];
-      const transfersOut = [];
-      const creditsIssuedSales = [];
-      const offsetNumbers = [];
+      let creditBalanceStart = { year: '', A: 0, B: 0 };
+      const creditBalanceEnd = { A: 0, B: 0 };
+      const provisionalBalance = { A: 0, B: 0 };
+      const pendingBalance = { A: 0, B: 0 };
+      const transfersIn = { A: 0, B: 0 };
+      const transfersOut = { A: 0, B: 0 };
+      const creditsIssuedSales = { A: 0, B: 0 };
+      const offsetNumbers = { A: 0, B: 0 };
       creditActivityResponse.data.forEach((item) => {
         if (item.category === 'creditBalanceStart') {
-          creditBalanceStart[item.modelYear.name] = { A: item.creditAValue, B: item.creditBValue };
+          creditBalanceStart.year = item.modelYear.name;
+          creditBalanceStart.A = item.creditAValue;
+          creditBalanceStart.B = item.creditBValue;
         }
         if (item.category === 'creditBalanceEnd') {
-          creditBalanceEnd[item.modelYear.name] = { A: item.creditAValue, B: item.creditBValue };
+          const aValue = parseFloat(item.creditAValue);
+          const bValue = parseFloat(item.creditBValue);
+          creditBalanceEnd.A += aValue;
+          creditBalanceEnd.B += bValue;
         }
         if (item.category === 'provisionalBalance') {
-          provisionalBalance[item.modelYear.name] = { A: parseFloat(item.creditAValue), B: parseFloat(item.creditBValue) };
+          const aValue = parseFloat(item.creditAValue);
+          const bValue = parseFloat(item.creditBValue);
+          provisionalBalance.A += aValue;
+          provisionalBalance.B += bValue;
         }
         if (item.category === 'pendingBalance') {
-          pendingBalance[item.modelYear.name] = { A: item.creditAValue, B: item.creditBValue };
+          const aValue = parseFloat(item.creditAValue);
+          const bValue = parseFloat(item.creditBValue);
+          pendingBalance.A += aValue;
+          pendingBalance.B += bValue;
         }
         if (item.category === 'transfersIn') {
-          transfersIn.push({ modelYear: item.modelYear.name, A: item.creditAValue, B: item.creditBValue });
+          const aValue = parseFloat(item.creditAValue);
+          const bValue = parseFloat(item.creditBValue);
+          transfersIn.A += aValue;
+          transfersIn.B += bValue;
         }
         if (item.category === 'transfersOut') {
-          transfersOut.push({ modelYear: item.modelYear.name, A: item.creditAValue, B: item.creditBValue });
+          const aValue = parseFloat(item.creditAValue);
+          const bValue = parseFloat(item.creditBValue);
+          transfersOut.A -= aValue;
+          transfersOut.B -= bValue;
         }
         if (item.category === 'creditsIssuedSales') {
-          creditsIssuedSales.push({ modelYear: item.modelYear.name, A: item.creditAValue, B: item.creditBValue });
+          const aValue = parseFloat(item.creditAValue);
+          const bValue = parseFloat(item.creditBValue);
+          creditsIssuedSales.A += aValue;
+          creditsIssuedSales.B += bValue;
         }
       });
       setCreditActivityDetails({
@@ -281,7 +217,6 @@ const ComplianceReportSummaryContainer = (props) => {
         user={user}
         loading={loading}
         handleSubmit={handleSubmit}
-        year="2020"
         makes={makes}
       />
 

--- a/frontend/src/compliance/ComplianceReportSummaryContainer.js
+++ b/frontend/src/compliance/ComplianceReportSummaryContainer.js
@@ -20,6 +20,7 @@ const ComplianceReportSummaryContainer = (props) => {
   const [complianceRatios, setComplianceRatios] = useState({});
   const [supplierDetails, setSupplierDetails] = useState({});
   const [makes, setMakes] = useState({});
+  const [creditActivityDetails, setCreditActivityDetails] = useState({})
   const [assertions, setAssertions] = useState([{ id: 0, description: 'On behalf of [insert supplier name], I confirm the information included in this Model Year report is complete and accurate' }]);
   const handleCheckboxClick = (event) => {
     if (!event.target.checked) {
@@ -50,101 +51,89 @@ const ComplianceReportSummaryContainer = (props) => {
     reportSummary: 'draft',
     supplierInformation: '',
   };
-  const creditsIssuedDetails = {
-    startingBalance: { A: 0, B: 0 },
-    endingBalance: { A: 1513.09, B: 191.29 },
-    creditsIssuedSales:
-      [
-        {
-          year: 2020,
-          A: 359.12,
-          B: 43.43,
-        },
-        {
-          year: 2019,
-          A: 1367.43,
-          B: 347.86,
-        },
-      ],
-    creditsIssuedInitiative:
-      [{
-        year: 2019,
-        A: 286.54,
-      }],
-    creditsIssuedPurchase: [
-      {
-        year: 2020,
-        A: 100.00,
-      },
-    ],
-    creditsTransferredIn: [
-      {
-        year: 2020,
-        A: 200.00,
-      },
-    ],
-    creditsTransferredAway: [
-      {
-        year: 2020,
-        A: -800.00,
-        B: -200.00,
-      },
-    ],
-    pendingSales: [
-      {
-        year: 2020,
-        A: 246.67,
-        B: 0,
-      },
-    ],
-    provisionalBalance: [
-      {
-        year: 2020,
-        A: 1192.33,
-        B: 43.43,
-      },
-      {
-        year: 2019,
-        A: 567.43,
-        B: 147.86,
-      },
-    ],
-    creditOffset: [
-      {
-        year: 2019,
-        A: -300,
-        B: -100,
-      },
-      {
-        year: 2020,
-        A: -458.71,
-        B: -91.29,
-      },
-    ],
-    provisionalAssessedBalance: [
-      {
-        year: 2019,
-        A: 754.38,
-        B: 0,
-      },
-      {
-        year: 2020,
-        A: 0,
-        B: 0,
-      },
-    ],
-  };
-  // const supplierInformationDetails = {
-  //   supplierInformation: {
-  //     makes: ['TOYOTA'],
-  //     history: [{
-  //       status: 'DRAFT',
-  //       createTimestamp: now(),
-  //       createUser: user,
+  // const creditsIssuedDetails = {
+  //   startingBalance: { A: 0, B: 0 },
+  //   endingBalance: { A: 1513.09, B: 191.29 },
+  //   creditsIssuedSales:
+  //     [
+  //       {
+  //         year: 2020,
+  //         A: 359.12,
+  //         B: 43.43,
+  //       },
+  //       {
+  //         year: 2019,
+  //         A: 1367.43,
+  //         B: 347.86,
+  //       },
+  //     ],
+  //   creditsIssuedInitiative:
+  //     [{
+  //       year: 2019,
+  //       A: 286.54,
   //     }],
-  //     status: 'DRAFT',
-  //   },
-  //   organization: user.organization,
+  //   creditsIssuedPurchase: [
+  //     {
+  //       year: 2020,
+  //       A: 100.00,
+  //     },
+  //   ],
+  //   creditsTransferredIn: [
+  //     {
+  //       year: 2020,
+  //       A: 200.00,
+  //     },
+  //   ],
+  //   creditsTransferredAway: [
+  //     {
+  //       year: 2020,
+  //       A: -800.00,
+  //       B: -200.00,
+  //     },
+  //   ],
+  //   pendingSales: [
+  //     {
+  //       year: 2020,
+  //       A: 246.67,
+  //       B: 0,
+  //     },
+  //   ],
+  //   provisionalBalance: [
+  //     {
+  //       year: 2020,
+  //       A: 1192.33,
+  //       B: 43.43,
+  //     },
+  //     {
+  //       year: 2019,
+  //       A: 567.43,
+  //       B: 147.86,
+  //     },
+  //   ],
+  //   creditOffset: [
+  //     {
+  //       year: 2019,
+  //       A: -300,
+  //       B: -100,
+  //     },
+  //     {
+  //       year: 2020,
+  //       A: -458.71,
+  //       B: -91.29,
+  //     },
+  //   ],
+  //   provisionalAssessedBalance: [
+  //     {
+  //       year: 2019,
+  //       A: 754.38,
+  //       B: 0,
+  //     },
+  //     {
+  //       year: 2020,
+  //       A: 0,
+  //       B: 0,
+  //     },
+  //   ],
   // };
   const refreshDetails = () => {
     setLoading(true);
@@ -218,8 +207,50 @@ const ComplianceReportSummaryContainer = (props) => {
       });
       setComplianceRatios(allComplianceRatiosResponse.data
         .filter((each) => each.modelYear === year));
+
       // CREDIT ACTIVITY
-      console.log(creditActivityResponse.data)
+      const creditBalanceStart = {};
+      const creditBalanceEnd = {};
+      const provisionalBalance = {};
+      const pendingBalance = {};
+      const transfersIn = [];
+      const transfersOut = [];
+      const creditsIssuedSales = [];
+      const offsetNumbers = [];
+      creditActivityResponse.data.forEach((item) => {
+        if (item.category === 'creditBalanceStart') {
+          creditBalanceStart[item.modelYear.name] = { A: item.creditAValue, B: item.creditBValue };
+        }
+        if (item.category === 'creditBalanceEnd') {
+          creditBalanceEnd[item.modelYear.name] = { A: item.creditAValue, B: item.creditBValue };
+        }
+        if (item.category === 'provisionalBalance') {
+          provisionalBalance[item.modelYear.name] = { A: parseFloat(item.creditAValue), B: parseFloat(item.creditBValue) };
+        }
+        if (item.category === 'pendingBalance') {
+          pendingBalance[item.modelYear.name] = { A: item.creditAValue, B: item.creditBValue };
+        }
+        if (item.category === 'transfersIn') {
+          transfersIn.push({ modelYear: item.modelYear.name, A: item.creditAValue, B: item.creditBValue });
+        }
+        if (item.category === 'transfersOut') {
+          transfersOut.push({ modelYear: item.modelYear.name, A: item.creditAValue, B: item.creditBValue });
+        }
+        if (item.category === 'creditsIssuedSales') {
+          creditsIssuedSales.push({ modelYear: item.modelYear.name, A: item.creditAValue, B: item.creditBValue });
+        }
+      });
+      setCreditActivityDetails({
+        creditBalanceStart,
+        creditBalanceEnd,
+        pendingBalance,
+        provisionalBalance,
+        transactions: {
+          creditsIssuedSales,
+          transfersIn,
+          transfersOut,
+        },
+      });
       setLoading(false);
     }));
   };
@@ -244,7 +275,7 @@ const ComplianceReportSummaryContainer = (props) => {
         handleCheckboxClick={handleCheckboxClick}
         checkboxes={checkboxes}
         assertions={assertions}
-        creditsIssuedDetails={creditsIssuedDetails}
+        creditActivityDetails={creditActivityDetails}
         consumerSalesDetails={consumerSalesDetails}
         supplierDetails={supplierDetails}
         user={user}

--- a/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
+++ b/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import moment from 'moment-timezone';
 import formatNumeric from '../../app/utilities/formatNumeric';
 import Button from '../../app/components/Button';
 import Loading from '../../app/components/Loading';
@@ -12,7 +13,6 @@ import SummaryCreditActivityTable from './SummaryCreditActivityTable';
 import SummarySupplierInfo from './SummarySupplierInfo';
 import SummaryConsumerSalesTable from './SummaryConsumerSalesTable';
 import Modal from '../../app/components/Modal';
-import moment from 'moment-timezone';
 
 const ComplianceReportSummaryDetailsPage = (props) => {
   const [showModal, setShowModal] = useState(false);
@@ -30,7 +30,6 @@ const ComplianceReportSummaryDetailsPage = (props) => {
     makes,
     confirmationStatuses,
   } = props;
-  console.log(confirmationStatuses);
   const signedInfomation = {
     supplierInformation: { nameSigned: 'Buzz Collins', dateSigned: '2020-01-01' },
     consumerSales: { nameSigned: 'Buzz Collins', dateSigned: '2020-02-20' },
@@ -42,7 +41,6 @@ const ComplianceReportSummaryDetailsPage = (props) => {
   }
   const signatureInformation = (input, title) => {
     const { status, confirmedBy } = input;
-    console.log(input)
     return (
       <div className="mt-3">
         {confirmedBy && (
@@ -52,8 +50,8 @@ const ComplianceReportSummaryDetailsPage = (props) => {
         )}
         {status !== 'CONFIRMED' && (
           <span className="text-red">
-          {title} pending confirmation
-        </span>
+            {title} pending confirmation
+          </span>
         )}
       </div>
     );

--- a/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
+++ b/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
@@ -12,6 +12,7 @@ import SummaryCreditActivityTable from './SummaryCreditActivityTable';
 import SummarySupplierInfo from './SummarySupplierInfo';
 import SummaryConsumerSalesTable from './SummaryConsumerSalesTable';
 import Modal from '../../app/components/Modal';
+import moment from 'moment-timezone';
 
 const ComplianceReportSummaryDetailsPage = (props) => {
   const [showModal, setShowModal] = useState(false);
@@ -27,9 +28,9 @@ const ComplianceReportSummaryDetailsPage = (props) => {
     consumerSalesDetails,
     handleCheckboxClick,
     makes,
-
+    confirmationStatuses,
   } = props;
-
+  console.log(confirmationStatuses);
   const signedInfomation = {
     supplierInformation: { nameSigned: 'Buzz Collins', dateSigned: '2020-01-01' },
     consumerSales: { nameSigned: 'Buzz Collins', dateSigned: '2020-02-20' },
@@ -39,13 +40,21 @@ const ComplianceReportSummaryDetailsPage = (props) => {
   if (loading) {
     return <Loading />;
   }
-  const signatureInformation = (input) => {
-    const { dateSigned, nameSigned } = input;
+  const signatureInformation = (input, title) => {
+    const { status, confirmedBy } = input;
+    console.log(input)
     return (
       <div className="mt-3">
-        <span className="text-blue">
-          Confirmed by {nameSigned} {dateSigned}
+        {confirmedBy && (
+          <span className="text-black">
+            {title} confirmed by {confirmedBy.createUser.displayName} {moment(confirmedBy.createTimestamp).format('YYYY-MM-DD h[:]mm a')}
+          </span>
+        )}
+        {status !== 'CONFIRMED' && (
+          <span className="text-red">
+          {title} pending confirmation
         </span>
+        )}
       </div>
     );
   };
@@ -87,13 +96,13 @@ const ComplianceReportSummaryDetailsPage = (props) => {
               <div className="col-lg-6">
                 <div className="compliance-report-summary-grey text-blue">
                   <SummarySupplierInfo makes={makes} supplierDetails={supplierDetails} signatureInformation={signatureInformation} signedInfomation={signedInfomation} />
-                  {signatureInformation(signedInfomation.supplierInformation)}
+                  {signatureInformation(confirmationStatuses.supplierInformation, 'Supplier Information')}
                 </div>
 
                 <div className="mt-4 compliance-report-summary-grey">
                   <h3>Consumer Sales</h3>
                   <SummaryConsumerSalesTable consumerSalesDetails={consumerSalesDetails} />
-                  {signatureInformation(signedInfomation.consumerSales)}
+                  {signatureInformation(confirmationStatuses.consumerSales, 'Consumer Sales')}
                 </div>
               </div>
               <div className="col-lg-6">
@@ -103,7 +112,7 @@ const ComplianceReportSummaryDetailsPage = (props) => {
                     consumerSalesDetails={consumerSalesDetails}
                     creditActivityDetails={creditActivityDetails}
                   />
-                  {signatureInformation(signedInfomation.creditActivity)}
+                  {signatureInformation(confirmationStatuses.complianceObligation, 'Compliance Obligation')}
                 </div>
               </div>
             </div>

--- a/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
+++ b/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
@@ -23,12 +23,14 @@ const ComplianceReportSummaryDetailsPage = (props) => {
     user,
     handleSubmit,
     loading,
-    supplierInformationDetails,
+    supplierDetails,
     consumerSalesDetails,
     handleCheckboxClick,
     year,
+    makes,
 
   } = props;
+
   const signedInfomation = {
     supplierInformation: { nameSigned: 'Buzz Collins', dateSigned: '2020-01-01' },
     consumerSales: { nameSigned: 'Buzz Collins', dateSigned: '2020-02-20' },
@@ -75,7 +77,7 @@ const ComplianceReportSummaryDetailsPage = (props) => {
       </div>
       <div className="row">
         <div className="col-12">
-          <ComplianceReportAlert report={supplierInformationDetails.supplierInformation} type="Summary" />
+          {/* <ComplianceReportAlert report={supplierDetails.supplierInformation} type="Summary" /> */}
         </div>
       </div>
       <div className="row mt-1">
@@ -85,7 +87,7 @@ const ComplianceReportSummaryDetailsPage = (props) => {
             <div className="row p3 mt-3">
               <div className="col-lg-6">
                 <div className="compliance-report-summary-grey text-blue">
-                  <SummarySupplierInfo supplierInformationDetails={supplierInformationDetails} signatureInformation={signatureInformation} signedInfomation={signedInfomation} />
+                  <SummarySupplierInfo makes={makes} supplierDetails={supplierDetails} signatureInformation={signatureInformation} signedInfomation={signedInfomation} />
                   {signatureInformation(signedInfomation.supplierInformation)}
                 </div>
 

--- a/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
+++ b/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
@@ -26,7 +26,6 @@ const ComplianceReportSummaryDetailsPage = (props) => {
     supplierDetails,
     consumerSalesDetails,
     handleCheckboxClick,
-    year,
     makes,
 
   } = props;
@@ -72,7 +71,7 @@ const ComplianceReportSummaryDetailsPage = (props) => {
     <div id="compliance-supplier-information-details" className="page">
       <div className="row mt-3">
         <div className="col-sm-12">
-          <h2>2020 Model Year Report</h2>
+          <h2>{consumerSalesDetails.year} Model Year Report</h2>
         </div>
       </div>
       <div className="row">
@@ -101,7 +100,6 @@ const ComplianceReportSummaryDetailsPage = (props) => {
                 <div className="compliance-report-summary-grey">
                   <SummaryCreditActivityTable
                     complianceRatios={complianceRatios}
-                    year={year}
                     consumerSalesDetails={consumerSalesDetails}
                     creditActivityDetails={creditActivityDetails}
                   />

--- a/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
+++ b/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
@@ -19,7 +19,7 @@ const ComplianceReportSummaryDetailsPage = (props) => {
     complianceRatios,
     assertions,
     checkboxes,
-    creditsIssuedDetails,
+    creditActivityDetails,
     user,
     handleSubmit,
     loading,
@@ -103,7 +103,7 @@ const ComplianceReportSummaryDetailsPage = (props) => {
                     complianceRatios={complianceRatios}
                     year={year}
                     consumerSalesDetails={consumerSalesDetails}
-                    creditsIssuedDetails={creditsIssuedDetails}
+                    creditActivityDetails={creditActivityDetails}
                   />
                   {signatureInformation(signedInfomation.creditActivity)}
                 </div>

--- a/frontend/src/compliance/components/SummaryCreditActivityTable.js
+++ b/frontend/src/compliance/components/SummaryCreditActivityTable.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { object } from 'prop-types';
 import formatNumeric from '../../app/utilities/formatNumeric';
 import SummarySupplierInfo from './SummarySupplierInfo';
 
@@ -7,24 +8,29 @@ const SummaryCreditActivityTable = (props) => {
     creditActivityDetails, consumerSalesDetails, complianceRatios,
   } = props;
   const { year, ldvSales, supplierClass } = consumerSalesDetails;
-  console.log(creditActivityDetails)
   const {
-    creditBalanceStart, creditBalanceEnd, transactions, 
+    creditBalanceStart, creditBalanceEnd, transactions,
     pendingBalance, provisionalBalance,
     creditOffset, provisionalAssessedBalance,
   } = creditActivityDetails;
 
   const tableSection = (input, title, numberClassname = 'text-right') => {
-    let aTotal;
-    let bTotal;
-    console.log(input)
-    if (Array.isArray(input)) {
-      aTotal = formatNumeric(input.reduce((a, v) => a + v.A, 0), 2);
-      bTotal = formatNumeric(input.reduce((a, v) => a + v.B, 0), 2);
-    } else {
-      aTotal = input.A;
-      bTotal = input.B;
-    }
+    let aTotal = formatNumeric(input.A);
+    let bTotal = formatNumeric(input.B);
+
+    // if (Array.isArray(input)) {
+    //   // console.log('array')
+    //   // console.log('title', title, 'input ',input)
+    //   aTotal = formatNumeric(input.reduce((a, v) => a + v.A, 0), 2);
+    //   bTotal = formatNumeric(input.reduce((a, v) => a + v.B, 0), 2);
+    // } else {
+    //   // console.log('not an array')
+    //   // console.log('title', title, 'input ',input)
+    //   Object.keys(input).forEach((each) => {
+    //     aTotal = input[each].A;
+    //     bTotal = input[each].B;
+    //   });
+    // };
     if (aTotal == 0.00) {
       aTotal = 0;
     }
@@ -68,7 +74,7 @@ const SummaryCreditActivityTable = (props) => {
       </tbody>
       <tbody>
 
-        {tableSection(creditBalanceStart, 'Balance at September 30, 2019:')}
+        {tableSection(creditBalanceStart, `Balance at September 30, ${creditBalanceStart.year} :`)}
         {Object.keys(transactions.creditsIssuedSales).length > 0
           && (
             tableSection(transactions.creditsIssuedSales, 'Consumer ZEV Sales:')
@@ -76,8 +82,8 @@ const SummaryCreditActivityTable = (props) => {
         {/* {Object.keys(creditsIssuedInitiative).length > 0
           && (
             tableSection(creditsIssuedInitiative, 'Initiative Agreements:')
-          )} */}
-        {/* {Object.keys(creditsIssuedPurchase).length > 0
+          )}
+        {Object.keys(creditsIssuedPurchase).length > 0
           && (
             tableSection(creditsIssuedPurchase, 'Purchase Agreements:')
           )} */}
@@ -143,6 +149,7 @@ const SummaryCreditActivityTable = (props) => {
               formatNumeric(ldvSales * (complianceRatios[0].complianceRatio / 100), 2))}
           </td>
         </tr>
+        {supplierClass === 'Large' && (
         <tr>
           <td className="text-blue">
             &bull; &nbsp; &nbsp; ZEV Class A Debit:
@@ -154,6 +161,7 @@ const SummaryCreditActivityTable = (props) => {
                 2))}
           </td>
         </tr>
+        )}
         <tr>
           <td className="text-blue">
             &bull; &nbsp; &nbsp; Unspecified ZEV Class Debit:

--- a/frontend/src/compliance/components/SummaryCreditActivityTable.js
+++ b/frontend/src/compliance/components/SummaryCreditActivityTable.js
@@ -4,19 +4,20 @@ import SummarySupplierInfo from './SummarySupplierInfo';
 
 const SummaryCreditActivityTable = (props) => {
   const {
-    creditsIssuedDetails, consumerSalesDetails, complianceRatios,
+    creditActivityDetails, consumerSalesDetails, complianceRatios,
   } = props;
   const { year, ldvSales, supplierClass } = consumerSalesDetails;
+  console.log(creditActivityDetails)
   const {
-    startingBalance, endingBalance,
-    creditsIssuedSales, creditsIssuedInitiative, creditsIssuedPurchase,
-    creditsTransferredIn, creditsTransferredAway, pendingSales, provisionalBalance,
+    creditBalanceStart, creditBalanceEnd, transactions, 
+    pendingBalance, provisionalBalance,
     creditOffset, provisionalAssessedBalance,
-  } = creditsIssuedDetails;
+  } = creditActivityDetails;
 
   const tableSection = (input, title, numberClassname = 'text-right') => {
     let aTotal;
     let bTotal;
+    console.log(input)
     if (Array.isArray(input)) {
       aTotal = formatNumeric(input.reduce((a, v) => a + v.A, 0), 2);
       bTotal = formatNumeric(input.reduce((a, v) => a + v.B, 0), 2);
@@ -67,44 +68,44 @@ const SummaryCreditActivityTable = (props) => {
       </tbody>
       <tbody>
 
-        {tableSection(startingBalance, 'Balance at September 30, 2019:')}
-        {Object.keys(creditsIssuedSales).length > 0
+        {tableSection(creditBalanceStart, 'Balance at September 30, 2019:')}
+        {Object.keys(transactions.creditsIssuedSales).length > 0
           && (
-            tableSection(creditsIssuedSales, 'Consumer ZEV Sales:')
+            tableSection(transactions.creditsIssuedSales, 'Consumer ZEV Sales:')
           )}
-        {Object.keys(creditsIssuedInitiative).length > 0
+        {/* {Object.keys(creditsIssuedInitiative).length > 0
           && (
             tableSection(creditsIssuedInitiative, 'Initiative Agreements:')
-          )}
-        {Object.keys(creditsIssuedPurchase).length > 0
+          )} */}
+        {/* {Object.keys(creditsIssuedPurchase).length > 0
           && (
             tableSection(creditsIssuedPurchase, 'Purchase Agreements:')
-          )}
-        {Object.keys(creditsTransferredIn).length > 0
+          )} */}
+        {Object.keys(transactions.transfersIn).length > 0
           && (
-            tableSection(creditsTransferredIn, 'Transferred In:')
+            tableSection(transactions.transfersIn, 'Transferred In:')
           )}
-        {Object.keys(creditsTransferredAway).length > 0
+        {Object.keys(transactions.transfersOut).length > 0
           && (
-            tableSection(creditsTransferredAway, 'Transferred Away:', 'text-red text-right')
+            tableSection(transactions.transfersOut, 'Transferred Away:', 'text-red text-right')
           )}
-        {tableSection(endingBalance, 'Balance at September 30, 2020:')}
-        {Object.keys(pendingSales).length > 0
+        {tableSection(creditBalanceEnd, 'Balance at September 30, 2020:')}
+        {Object.keys(pendingBalance).length > 0
           && (
-            tableSection(pendingSales, 'Pending for Consumer Sales:')
+            tableSection(pendingBalance, 'Pending for Consumer Sales:')
           )}
         {Object.keys(provisionalBalance).length > 0
           && (
             tableSection(provisionalBalance, 'Provisional Credit Balance:')
           )}
-        {Object.keys(creditOffset).length > 0
+        {/* {Object.keys(creditOffset).length > 0
           && (
             tableSection(creditOffset, 'Credit Offset:', 'text-red text-right')
-          )}
-        {Object.keys(provisionalAssessedBalance).length > 0
+          )} */}
+        {/* {Object.keys(provisionalAssessedBalance).length > 0
           && (
             tableSection(provisionalAssessedBalance, 'Provisional assessed balance:')
-          )}
+          )} */}
       </tbody>
       <tbody className="mt-3">
         <tr>

--- a/frontend/src/compliance/components/SummarySupplierInfo.js
+++ b/frontend/src/compliance/components/SummarySupplierInfo.js
@@ -1,9 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const SummarySupplierInfo = (props) => {
   const { supplierDetails, makes } = props;
-  const { organization, supplierInformation } = supplierDetails;
-  console.log(organization.organizationAddress)
+  const { organization } = supplierDetails;
   return (
     <>
       <h3>Supplier Information</h3>
@@ -48,10 +48,14 @@ const SummarySupplierInfo = (props) => {
         </div>
         <div className="d-block my-3">
           <h4>Makes:</h4>
-          {makes.map((each) => <div>•{each}</div>)}
+          {makes.map((each) => <div key={each}>•{each}</div>)}
         </div>
       </div>
     </>
   );
+};
+SummarySupplierInfo.propTypes = {
+  supplierDetails: PropTypes.shape().isRequired,
+  makes: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 export default SummarySupplierInfo;

--- a/frontend/src/compliance/components/SummarySupplierInfo.js
+++ b/frontend/src/compliance/components/SummarySupplierInfo.js
@@ -1,8 +1,9 @@
 import React from 'react';
 
 const SummarySupplierInfo = (props) => {
-  const { supplierInformationDetails } = props;
-  const { organization, supplierInformation } = supplierInformationDetails
+  const { supplierDetails, makes } = props;
+  const { organization, supplierInformation } = supplierDetails;
+  console.log(organization.organizationAddress)
   return (
     <>
       <h3>Supplier Information</h3>
@@ -47,7 +48,7 @@ const SummarySupplierInfo = (props) => {
         </div>
         <div className="d-block my-3">
           <h4>Makes:</h4>
-          {supplierInformation.makes.map((each) => `•  ${each}`)}
+          {makes.map((each) => <div>•{each}</div>)}
         </div>
       </div>
     </>


### PR DESCRIPTION
-changes obligation serializer to use id instead of year (also updates frontend)
-adds axios calls to summary container for report, supplier, consumer sales, and obligation detsails
-reworks how summary tables receive data (format has changed since frontend was originally developed)