### PR TITLE
Zeva541 - idir snapshot of model year report

### DIFF
--- a/frontend/src/app/router.js
+++ b/frontend/src/app/router.js
@@ -158,7 +158,7 @@ class Router extends Component {
               />
               <Route
                 path={ROUTES_COMPLIANCE.REPORT_SUMMARY}
-                render={() => ((typeof user.hasPermission === 'function' && user.hasPermission('EDIT_SALES') && !user.isGovernment)
+                render={() => ((typeof user.hasPermission === 'function' && user.hasPermission('EDIT_SALES'))
                   ? <ComplianceReportSummaryContainer keycloak={keycloak} user={user} /> : (
                     <ComplianceReportsContainer keycloak={keycloak} user={user} />
                   ))}

--- a/frontend/src/compliance/ComplianceReportSummaryContainer.js
+++ b/frontend/src/compliance/ComplianceReportSummaryContainer.js
@@ -135,13 +135,13 @@ const ComplianceReportSummaryContainer = (props) => {
       // CREDIT ACTIVITY
       const creditBalanceStart = { year: '', A: 0, B: 0 };
       const creditBalanceEnd = { A: 0, B: 0 };
-      const provisionalBalance = { A: 0, B: 0 };
+      const provisionalBalance = { year: '', A: 0, B: 0 };
       const pendingBalance = { A: 0, B: 0 };
       const transfersIn = { A: 0, B: 0 };
       const transfersOut = { A: 0, B: 0 };
       const creditsIssuedSales = { A: 0, B: 0 };
       const offsetNumbers = { A: 0, B: 0 };
-      creditActivityResponse.data.forEach((item) => {
+      creditActivityResponse.data.complianceObligation.forEach((item) => {
         if (item.category === 'creditBalanceStart') {
           creditBalanceStart.year = item.modelYear.name;
           creditBalanceStart.A = item.creditAValue;

--- a/frontend/src/compliance/ComplianceReportSummaryContainer.js
+++ b/frontend/src/compliance/ComplianceReportSummaryContainer.js
@@ -135,7 +135,7 @@ const ComplianceReportSummaryContainer = (props) => {
       // CREDIT ACTIVITY
       const creditBalanceStart = { year: '', A: 0, B: 0 };
       const creditBalanceEnd = { A: 0, B: 0 };
-      const provisionalBalance = { year: '', A: 0, B: 0 };
+      const provisionalBalance = {};
       const pendingBalance = { A: 0, B: 0 };
       const transfersIn = { A: 0, B: 0 };
       const transfersOut = { A: 0, B: 0 };

--- a/frontend/src/compliance/ComplianceReportSummaryContainer.js
+++ b/frontend/src/compliance/ComplianceReportSummaryContainer.js
@@ -25,7 +25,7 @@ const ComplianceReportSummaryContainer = (props) => {
   const [creditActivityDetails, setCreditActivityDetails] = useState({});
   const [pendingBalanceExist, setPendingBalanceExist] = useState(false);
   const [assertions, setAssertions] = useState([]);
-  
+
   const handleCheckboxClick = (event) => {
     if (!event.target.checked) {
       const checked = checkboxes.filter((each) => Number(each) !== Number(event.target.id));
@@ -41,7 +41,7 @@ const ComplianceReportSummaryContainer = (props) => {
     const data = {
       modelYearReportId: id,
       validation_status: status,
-      confirmation: checkboxes
+      confirmation: checkboxes,
     };
 
     axios.patch(ROUTES_COMPLIANCE.REPORT_SUBMISSION, data).then((response) => {

--- a/frontend/src/compliance/components/ComplianceObligationDetailsPage.js
+++ b/frontend/src/compliance/components/ComplianceObligationDetailsPage.js
@@ -135,6 +135,7 @@ const ComplianceObligationDetailsPage = (props) => {
           creditReduction={creditReduction}
           supplierClassInfo={supplierClassInfo}
           handleOffsetChange={handleOffsetChange}
+          user={user}
         />
       </div>
       <ComplianceReportSignoff

--- a/frontend/src/compliance/components/ComplianceObligationDetailsPage.js
+++ b/frontend/src/compliance/components/ComplianceObligationDetailsPage.js
@@ -40,9 +40,8 @@ const ComplianceObligationDetailsPage = (props) => {
   } = props;
   const [showModal, setShowModal] = useState(false);
   let disabledCheckboxes = propsDisabledCheckboxes;
-
   const totalReduction = ((ratios.complianceRatio / 100) * supplierClassInfo.ldvSales);
-  
+
   const classAReduction = formatNumeric(
     ((ratios.zevClassA / 100) * supplierClassInfo.ldvSales),
     2,
@@ -130,6 +129,7 @@ const ComplianceObligationDetailsPage = (props) => {
         <h3 className="mt-4 mb-2">Credit Reduction</h3>
         You must select your ZEV class credit preference below.
         <ComplianceObligationReductionOffsetTable
+          statuses={statuses}
           offsetNumbers={offsetNumbers}
           unspecifiedCreditReduction={unspecifiedCreditReduction}
           supplierClassInfo={supplierClassInfo}
@@ -205,7 +205,7 @@ ComplianceObligationDetailsPage.propTypes = {
   handleCheckboxClick: PropTypes.func.isRequired,
   assertions: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   checkboxes: PropTypes.arrayOf(
-    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   ).isRequired,
   statuses: PropTypes.shape().isRequired,
   handleOffsetChange: PropTypes.func.isRequired,

--- a/frontend/src/compliance/components/ComplianceObligationDetailsPage.js
+++ b/frontend/src/compliance/components/ComplianceObligationDetailsPage.js
@@ -159,12 +159,14 @@ const ComplianceObligationDetailsPage = (props) => {
                   history.push(ROUTES_COMPLIANCE.REPORT_SUMMARY.replace(':id', id));
                 }}
               />
+              {!user.isGovernment && (
               <Button
                 buttonType="save"
                 disabled={['SAVED', 'UNSAVED'].indexOf(statuses.complianceObligation.status) < 0}
                 optionalClassname="button primary"
                 action={() => { handleSave(); }}
               />
+              )}
             </span>
           </div>
         </div>

--- a/frontend/src/compliance/components/ComplianceObligationReductionOffsetTable.js
+++ b/frontend/src/compliance/components/ComplianceObligationReductionOffsetTable.js
@@ -11,7 +11,7 @@ const ComplianceObligationReductionOffsetTable = (props) => {
     creditBalance,
     totalReduction,
     user,
-    statuses
+    statuses,
   } = props;
 
   return (
@@ -81,7 +81,7 @@ const ComplianceObligationReductionOffsetTable = (props) => {
                       event,
                       supplierClassInfo.class === 'L'
                         ? leftoverReduction
-                        : totalReduction
+                        : totalReduction,
                     );
                   }}
                   name="creditOption"
@@ -99,7 +99,7 @@ const ComplianceObligationReductionOffsetTable = (props) => {
                       event,
                       supplierClassInfo.class === 'L'
                         ? leftoverReduction
-                        : totalReduction
+                        : totalReduction,
                     );
                   }}
                   name="creditOption"
@@ -167,8 +167,8 @@ const ComplianceObligationReductionOffsetTable = (props) => {
 
             <tr className="subclass">
               <th className="large-column">BALANCE AFTER CREDIT REDUCTION</th>
-              <th></th>
-              <th></th>
+              <th />
+              <th />
             </tr>
             <tr>
               <td className="text-blue">

--- a/frontend/src/compliance/components/ComplianceObligationReductionOffsetTable.js
+++ b/frontend/src/compliance/components/ComplianceObligationReductionOffsetTable.js
@@ -73,7 +73,7 @@ const ComplianceObligationReductionOffsetTable = (props) => {
               </td>
               <td className="text-center">
                 <input
-                  disabled={user.isGovernment || statuses.complianceObligation.status === 'SUBMITTED'}
+                  disabled={user.isGovernment || statuses.complianceObligation.status === 'SUBMITTED' || statuses.complianceObligation.status === 'CONFIRMED'}
                   type="radio"
                   id="A"
                   onChange={(event) => {
@@ -90,7 +90,7 @@ const ComplianceObligationReductionOffsetTable = (props) => {
               </td>
               <td className="text-center">
                 <input
-                  disabled={user.isGovernment || statuses.complianceObligation.status === 'SUBMITTED'}
+                  disabled={user.isGovernment || statuses.complianceObligation.status === 'SUBMITTED' || statuses.complianceObligation.status === 'CONFIRMED'}
                   className="text-center"
                   type="radio"
                   id="B"

--- a/frontend/src/compliance/components/ComplianceObligationReductionOffsetTable.js
+++ b/frontend/src/compliance/components/ComplianceObligationReductionOffsetTable.js
@@ -11,6 +11,7 @@ const ComplianceObligationReductionOffsetTable = (props) => {
     creditBalance,
     totalReduction,
     user,
+    statuses
   } = props;
 
   return (
@@ -72,7 +73,7 @@ const ComplianceObligationReductionOffsetTable = (props) => {
               </td>
               <td className="text-center">
                 <input
-                  disabled={user.isGovernment}
+                  disabled={user.isGovernment || statuses.complianceObligation.status === 'SUBMITTED'}
                   type="radio"
                   id="A"
                   onChange={(event) => {
@@ -89,7 +90,7 @@ const ComplianceObligationReductionOffsetTable = (props) => {
               </td>
               <td className="text-center">
                 <input
-                  disabled={user.isGovernment}
+                  disabled={user.isGovernment || statuses.complianceObligation.status === 'SUBMITTED'}
                   className="text-center"
                   type="radio"
                   id="B"

--- a/frontend/src/compliance/components/ComplianceObligationReductionOffsetTable.js
+++ b/frontend/src/compliance/components/ComplianceObligationReductionOffsetTable.js
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { useReducer } from 'react';
 import PropTypes from 'prop-types';
 import formatNumeric from '../../app/utilities/formatNumeric';
 
 const ComplianceObligationReductionOffsetTable = (props) => {
   const {
-    offsetNumbers, creditReduction, supplierClassInfo, handleOffsetChange,
+    user, offsetNumbers, creditReduction, supplierClassInfo, handleOffsetChange,
   } = props;
 
   return (
@@ -63,6 +63,7 @@ const ComplianceObligationReductionOffsetTable = (props) => {
               </td>
               <td className="text-center">
                 <input
+                  disabled={user.isGovernment}
                   type="radio"
                   id="A"
                   onChange={(event) => {
@@ -74,6 +75,7 @@ const ComplianceObligationReductionOffsetTable = (props) => {
               </td>
               <td className="text-center">
                 <input
+                  disabled={user.isGovernment}
                   className="text-center"
                   type="radio"
                   id="B"

--- a/frontend/src/compliance/components/ComplianceReportAlert.js
+++ b/frontend/src/compliance/components/ComplianceReportAlert.js
@@ -61,9 +61,9 @@ const ComplianceReportAlert = (props) => {
       break;
 
     case 'SUBMITTED':
-      title = 'Model Year Report Submitted';
-      message = `Model Year Report Submitted ${date} by ${userName} — Consumer Sales confirmed ${confirmedBy.date} by ${confirmedBy.user}`;
-      classname = 'alert-primary';
+      title = 'Submitted';
+      message = `Model Year Report Submitted ${date} by ${userName}. Pending analyst review and director assessment`;
+      classname = 'alert-warning';
       break;
 
     case 'ASSESSED':

--- a/frontend/src/compliance/components/ComplianceReportAlert.js
+++ b/frontend/src/compliance/components/ComplianceReportAlert.js
@@ -97,9 +97,9 @@ const ComplianceReportAlert = (props) => {
       break;
 
     case 'SUBMITTED':
-      title = 'Submitted';
-      message = `Model Year Report Submitted ${date} by ${userName}. Pending analyst review and director assessment`;
-      classname = 'alert-warning';
+      title = 'Model Year Report Submitted';
+      message = `Model Year Report Submitted ${date} by ${userName} — ${type} confirmed ${confirmedBy.date} by ${confirmedBy.user}`;
+      classname = 'alert-primary';
       break;
 
     case 'ASSESSED':

--- a/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
+++ b/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
@@ -36,12 +36,12 @@ const ComplianceReportSummaryDetailsPage = (props) => {
     consumerSales: { nameSigned: 'Buzz Collins', dateSigned: '2020-02-20' },
     creditActivity: { nameSigned: 'Buzz Collins', dateSigned: '2020-03-01' },
   };
-
   if (loading) {
     return <Loading />;
   }
   const signatureInformation = (input, title) => {
     const { status, confirmedBy } = input;
+
     return (
       <div className="mt-3">
         {confirmedBy && (
@@ -49,7 +49,7 @@ const ComplianceReportSummaryDetailsPage = (props) => {
             {title} confirmed by {confirmedBy.createUser.displayName} {moment(confirmedBy.createTimestamp).format('YYYY-MM-DD h[:]mm a')}
           </span>
         )}
-        {status !== 'CONFIRMED' && (
+        {status !== 'CONFIRMED' && status !== 'SUBMITTED' && !confirmedBy && (
           <span className="text-red">
             {title} pending confirmation
           </span>
@@ -60,15 +60,14 @@ const ComplianceReportSummaryDetailsPage = (props) => {
 
   const disableCheckbox = (confirmationStatuses) => {
     const { supplierInformation, consumerSales, complianceObligation } = confirmationStatuses;
-    if (user.hasPermission('SUBMIT_COMPLIANCE_REPORT') &&
-      supplierInformation.status === "CONFIRMED" &&
-      consumerSales.status === "CONFIRMED" &&
-      complianceObligation.status === "CONFIRMED") {
+    if (user.hasPermission('SUBMIT_COMPLIANCE_REPORT')
+      && supplierInformation.status === 'CONFIRMED'
+      && consumerSales.status === 'CONFIRMED'
+      && complianceObligation.status === 'CONFIRMED') {
       return false;
-    } else {
-      return true;
     }
-  }
+    return true;
+  };
 
   const modal = (
     <Modal
@@ -97,7 +96,12 @@ const ComplianceReportSummaryDetailsPage = (props) => {
       </div>
       <div className="row">
         <div className="col-12">
-          {/* <ComplianceReportAlert report={supplierInformationDetails.supplierInformation} type="Summary" /> */}
+          <ComplianceReportAlert
+            next="Assessment"
+            report={supplierDetails.supplierInformation}
+            status={confirmationStatuses.consumerSales}
+            type="Summary"
+          />
         </div>
       </div>
       <div className="row mt-1">
@@ -153,14 +157,16 @@ const ComplianceReportSummaryDetailsPage = (props) => {
               <Button buttonType="back" locationRoute="/compliance/reports" />
             </span>
             <span className="right-content">
-              <Button
-                buttonType="submit"
-                disabled={checkboxes.length < assertions.length || !user.hasPermission('SUBMIT_COMPLIANCE_REPORT')}
-                optionalClassname="button primary"
-                action={(event) => {
-                  setShowModal(true);
-                }}
-              />
+              {!user.isGovernment && (
+                <Button
+                  buttonType="submit"
+                  disabled={checkboxes.length < assertions.length || !user.hasPermission('SUBMIT_COMPLIANCE_REPORT')}
+                  optionalClassname="button primary"
+                  action={(event) => {
+                    setShowModal(true);
+                  }}
+                />
+              )}
             </span>
           </div>
         </div>

--- a/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
+++ b/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
@@ -142,6 +142,7 @@ const ConsumerSalesDetailsPage = (props) => {
                     type="number"
                     onChange={handleChange}
                     min="0"
+                    disabled={user.isGovernment}
                   />
                   {error && (
                     <small className="text-danger ml-2">
@@ -292,7 +293,7 @@ const ConsumerSalesDetailsPage = (props) => {
                   history.push(ROUTES_COMPLIANCE.REPORT_CREDIT_ACTIVITY.replace(':id', id));
                 }}
               />
-
+              {!user.isGovernment && (
               <Button
                 buttonType="save"
                 disabled={['SAVED', 'UNSAVED'].indexOf(statuses.consumerSales.status) < 0}
@@ -301,6 +302,7 @@ const ConsumerSalesDetailsPage = (props) => {
                   handleSave(event);
                 }}
               />
+              )}
             </span>
           </div>
         </div>

--- a/frontend/src/compliance/components/SupplierInformationDetailsPage.js
+++ b/frontend/src/compliance/components/SupplierInformationDetailsPage.js
@@ -230,7 +230,7 @@ const SupplierInformationDetailsPage = (props) => {
                   history.push(ROUTES_COMPLIANCE.REPORT_CONSUMER_SALES.replace(':id', id));
                 }}
               />
-
+              {!user.isGovernment && (
               <Button
                 buttonType="save"
                 disabled={['SAVED', 'UNSAVED'].indexOf(statuses.supplierInformation.status) < 0}
@@ -239,6 +239,7 @@ const SupplierInformationDetailsPage = (props) => {
                   handleSubmit(event);
                 }}
               />
+              )}
             </span>
           </div>
         </div>


### PR DESCRIPTION
Allow the analyst/engineer to select a report from the report list page
Load/enable view of the snapshot of the submitted report (4 pages)
The pages should be read only, and are therefore a record of the information submitted by the supplier

-disables any inputs or radio buttons if user is gov
-removes save buttons for gov users as well