### PR TITLE
ZEVA-553: Implement the time period logic (October to September) for the consumer sales vehicles

### DIFF
--- a/frontend/src/app/routes/Vehicles.js
+++ b/frontend/src/app/routes/Vehicles.js
@@ -3,7 +3,7 @@ const API_BASE_PATH = '/vehicles';
 const VEHICLES = {
   ADD: `${API_BASE_PATH}/add`,
   CLASSES: `${API_BASE_PATH}/classes`,
-  VEHICLES_SALES: `${API_BASE_PATH}/vehicles_sales`,
+  VEHICLES_SALES: `${API_BASE_PATH}/:id/vehicles_sales`,
   DETAILS: `${API_BASE_PATH}/:id`,
   EDIT: `${API_BASE_PATH}/:id/edit`,
   LIST: `${API_BASE_PATH}`,

--- a/frontend/src/compliance/ComplianceReportSummaryContainer.js
+++ b/frontend/src/compliance/ComplianceReportSummaryContainer.js
@@ -3,6 +3,7 @@ import { now } from 'moment';
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
+import CONFIG from '../app/config';
 import Loading from '../app/components/Loading';
 import ROUTES_COMPLIANCE from '../app/routes/Compliance';
 import CustomPropTypes from '../app/utilities/props';
@@ -24,6 +25,7 @@ const ComplianceReportSummaryContainer = (props) => {
   const [confirmationStatuses, setConfirmationStatuses] = useState({});
   const [creditActivityDetails, setCreditActivityDetails] = useState({});
   const [pendingBalanceExist, setPendingBalanceExist] = useState(false);
+  const [modelYear, setModelYear] = useState(CONFIG.FEATURES.MODEL_YEAR_REPORT.DEFAULT_YEAR);
   const [assertions, setAssertions] = useState([]);
   
   const handleCheckboxClick = (event) => {
@@ -61,13 +63,11 @@ const ComplianceReportSummaryContainer = (props) => {
     axios.all([
       axios.get(ROUTES_COMPLIANCE.REPORT_DETAILS.replace(/:id/g, id)),
       axios.get(ROUTES_COMPLIANCE.RATIOS),
-      axios.get(ROUTES_VEHICLES.VEHICLES_SALES),
       axios.get(ROUTES_COMPLIANCE.RETRIEVE_CONSUMER_SALES.replace(':id', id)),
       axios.get(ROUTES_COMPLIANCE.REPORT_COMPLIANCE_DETAILS_BY_ID.replace(':id', id)),
     ]).then(axios.spread((
       reportDetailsResponse,
       allComplianceRatiosResponse,
-      vehicleSalesResponse,
       consumerSalesResponse,
       creditActivityResponse,
     ) => {
@@ -83,6 +83,10 @@ const ComplianceReportSummaryContainer = (props) => {
       } = reportDetailsResponse.data;
       // ALL STATUSES
       setConfirmationStatuses(statuses);
+
+      const year = parseInt(reportModelYear.name, 10);
+
+      setModelYear(year);
 
       // SUPPLIER INFORMATION
       if (modelYearReportMakes) {
@@ -108,10 +112,10 @@ const ComplianceReportSummaryContainer = (props) => {
       } else {
         supplierClass = 'Small';
       }
-      const year = reportDetailsResponse.data.modelYear.name;
+
       let pendingZevSales = 0;
       let zevSales = 0;
-      vehicleSalesResponse.data.forEach((vehicle) => {
+      consumerSalesResponse.data.vehicleList.forEach((vehicle) => {
         pendingZevSales += vehicle.pendingSales;
         zevSales += vehicle.salesIssued;
       });
@@ -209,7 +213,7 @@ const ComplianceReportSummaryContainer = (props) => {
 
   useEffect(() => {
     refreshDetails();
-  }, []);
+  }, [modelYear]);
   if (loading) {
     return (<Loading />);
   }

--- a/frontend/src/compliance/ConsumerSalesContainer.js
+++ b/frontend/src/compliance/ConsumerSalesContainer.js
@@ -57,7 +57,7 @@ const ConsumerSalesContainer = (props) => {
     setLoading(showLoading);
 
     axios.all([
-      axios.get(ROUTES_VEHICLES.VEHICLES_SALES),
+      axios.get(ROUTES_VEHICLES.VEHICLES_SALES.replace(':id', modelYear)),
       axios.get(ROUTES_COMPLIANCE.RETRIEVE_CONSUMER_SALES.replace(':id', id)),
       axios.get(ROUTES_COMPLIANCE.REPORT_DETAILS.replace(/:id/g, id)),
     ]).then(axios.spread((vehiclesSales, consumerSalesResponse, statusesResponse) => {
@@ -240,7 +240,7 @@ const ConsumerSalesContainer = (props) => {
 
   useEffect(() => {
     refreshDetails(true);
-  }, [keycloak.authenticated]);
+  }, [keycloak.authenticated, modelYear]);
 
   return (
     <>


### PR DESCRIPTION
-Updated the vehicle_sales api to filter the sale submission record based on date
-made changes to summary page, get vehicleList from consumerSales snapshot.