### PR TITLE
ZEVA-571:Fix read-only logic when a page is confirmed, also fixed some issues with confirmation retrieval on summary page.

### DIFF
--- a/backend/api/viewsets/model_year_report.py
+++ b/backend/api/viewsets/model_year_report.py
@@ -126,11 +126,25 @@ class ModelYearReportViewset(
 
         return Response(serializer.data)
 
+    @action(detail=True)
+    def submission_confirmation(self, request, pk=None):
+        queryset = self.get_queryset()
+        report = get_object_or_404(queryset, pk=pk)
+
+        confirmation = ModelYearReportConfirmation.objects.filter(
+            model_year_report_id=pk,
+            signing_authority_assertion__module="compliance_summary"
+        ).values_list(
+                'signing_authority_assertion_id', flat=True
+        )
+
+        return Response({'confirmation': confirmation})
+
     @action(detail=False, methods=['patch'])
     def submission(self, request):
         validation_status = request.data.get('validation_status')
         model_year_report_id = request.data.get('model_year_report_id')
-        confirmation = request.data.get('confirmation')
+        confirmations = request.data.get('confirmation')
 
         model_year_report_update = ModelYearReport.objects.filter(
             id=model_year_report_id
@@ -146,13 +160,16 @@ class ModelYearReportViewset(
                 update_user=request.user.username,
                 create_user=request.user.username,
             )
-        
-        confirmation = ModelYearReportConfirmation.objects.filter(
-            model_year_report_id=model_year_report_id,
-            signing_authority_assertion__module="compliance_summary"
-        ).values_list(
-            'signing_authority_assertion_id', flat=True
-        ).distinct()
+
+        for confirmation in confirmations:
+            summary_confirmation = ModelYearReportConfirmation.objects.create(
+                create_user=request.user.username,
+                model_year_report_id=model_year_report_id,
+                has_accepted=True,
+                title=request.user.title,
+                signing_authority_assertion_id=confirmation
+            )
+            summary_confirmation.save()
 
         return HttpResponse(
             status=201, content="Report Submitted"

--- a/backend/api/viewsets/model_year_report.py
+++ b/backend/api/viewsets/model_year_report.py
@@ -128,9 +128,6 @@ class ModelYearReportViewset(
 
     @action(detail=True)
     def submission_confirmation(self, request, pk=None):
-        queryset = self.get_queryset()
-        report = get_object_or_404(queryset, pk=pk)
-
         confirmation = ModelYearReportConfirmation.objects.filter(
             model_year_report_id=pk,
             signing_authority_assertion__module="compliance_summary"

--- a/frontend/src/app/routes/Compliance.js
+++ b/frontend/src/app/routes/Compliance.js
@@ -16,6 +16,7 @@ const COMPLIANCE = {
   CONSUMER_SALES: `${API_BASE_PATH}/consumer-sales`,
   RETRIEVE_CONSUMER_SALES: `${API_BASE_PATH}/consumer-sales/:id`,
   REPORT_COMPLIANCE_DETAILS_BY_ID: `${API_BASE_PATH}/compliance-activity-details/:id`,
+  REPORT_SUMMARY_CONFIRMATION: `${API_BASE_PATH}/reports/:id/submission_confirmation`,
   REPORT_SUBMISSION: `${API_BASE_PATH}/reports/submission`,
 };
 

--- a/frontend/src/compliance/ComplianceReportSummaryContainer.js
+++ b/frontend/src/compliance/ComplianceReportSummaryContainer.js
@@ -1,15 +1,13 @@
 import axios from 'axios';
-import { now } from 'moment';
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import CONFIG from '../app/config';
+import history from '../app/History';
 import Loading from '../app/components/Loading';
 import ROUTES_COMPLIANCE from '../app/routes/Compliance';
 import CustomPropTypes from '../app/utilities/props';
 import ComplianceReportTabs from './components/ComplianceReportTabs';
 import ComplianceReportSummaryDetailsPage from './components/ComplianceReportSummaryDetailsPage';
-import ROUTES_VEHICLES from '../app/routes/Vehicles';
 import formatNumeric from '../app/utilities/formatNumeric';
 import ROUTES_SIGNING_AUTHORITY_ASSERTIONS from '../app/routes/SigningAuthorityAssertions';
 
@@ -30,12 +28,12 @@ const ComplianceReportSummaryContainer = (props) => {
 
   const handleCheckboxClick = (event) => {
     if (!event.target.checked) {
-      const checked = checkboxes.filter((each) => Number(each) !== Number(event.target.id));
+      const checked = checkboxes.filter((each) => Number(each) !== Number(parseInt(event.target.id,10)));
       setCheckboxes(checked);
     }
 
     if (event.target.checked) {
-      const checked = checkboxes.concat(event.target.id);
+      const checked = checkboxes.concat(parseInt(event.target.id,10));
       setCheckboxes(checked);
     }
   };
@@ -47,7 +45,8 @@ const ComplianceReportSummaryContainer = (props) => {
     };
 
     axios.patch(ROUTES_COMPLIANCE.REPORT_SUBMISSION, data).then((response) => {
-      console.log('Report Submitted ', response);
+      history.push(ROUTES_COMPLIANCE.REPORTS);
+      history.replace(ROUTES_COMPLIANCE.REPORT_SUMMARY.replace(':id', id));
     });
   };
 
@@ -55,11 +54,13 @@ const ComplianceReportSummaryContainer = (props) => {
     setLoading(true);
     axios.all([
       axios.get(ROUTES_COMPLIANCE.REPORT_DETAILS.replace(/:id/g, id)),
+      axios.get(ROUTES_COMPLIANCE.REPORT_SUMMARY_CONFIRMATION.replace(':id', id)),
       axios.get(ROUTES_COMPLIANCE.RATIOS),
       axios.get(ROUTES_COMPLIANCE.RETRIEVE_CONSUMER_SALES.replace(':id', id)),
       axios.get(ROUTES_COMPLIANCE.REPORT_COMPLIANCE_DETAILS_BY_ID.replace(':id', id)),
     ]).then(axios.spread((
       reportDetailsResponse,
+      summaryConfirmationResponse,
       allComplianceRatiosResponse,
       consumerSalesResponse,
       creditActivityResponse,
@@ -80,6 +81,8 @@ const ComplianceReportSummaryContainer = (props) => {
       const year = parseInt(reportModelYear.name, 10);
 
       setModelYear(year);
+      setCheckboxes(summaryConfirmationResponse.data.confirmation);
+      
 
       // SUPPLIER INFORMATION
       if (modelYearReportMakes) {

--- a/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
+++ b/frontend/src/compliance/components/ComplianceReportSummaryDetailsPage.js
@@ -34,6 +34,8 @@ const ComplianceReportSummaryDetailsPage = (props) => {
     consumerSales: { nameSigned: 'Buzz Collins', dateSigned: '2020-02-20' },
     creditActivity: { nameSigned: 'Buzz Collins', dateSigned: '2020-03-01' },
   };
+
+  let disableSubmitBtn = true;
   if (loading) {
     return <Loading />;
   }
@@ -66,6 +68,12 @@ const ComplianceReportSummaryDetailsPage = (props) => {
     }
     return true;
   };
+
+  assertions.forEach((assertion) => {
+    if (checkboxes.indexOf(assertion.id) >= 0) {
+      disableSubmitBtn = false;
+    }
+  });
 
   const modal = (
     <Modal
@@ -160,7 +168,7 @@ const ComplianceReportSummaryDetailsPage = (props) => {
               {!user.isGovernment && (
                 <Button
                   buttonType="submit"
-                  disabled={checkboxes.length < assertions.length || !user.hasPermission('SUBMIT_COMPLIANCE_REPORT')}
+                  disabled={disableSubmitBtn || confirmationStatuses.reportSummary.status === 'SUBMITTED' || !user.hasPermission('SUBMIT_COMPLIANCE_REPORT')}
                   optionalClassname="button primary"
                   action={(event) => {
                     setShowModal(true);

--- a/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
+++ b/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
@@ -142,7 +142,7 @@ const ConsumerSalesDetailsPage = (props) => {
                     type="number"
                     onChange={handleChange}
                     min="0"
-                    disabled={user.isGovernment}
+                    disabled={user.isGovernment || (['SAVED', 'UNSAVED'].indexOf(statuses.consumerSales.status) < 0)}
                   />
                   {error && (
                     <small className="text-danger ml-2">

--- a/frontend/src/compliance/components/SupplierInformationDetailsPage.js
+++ b/frontend/src/compliance/components/SupplierInformationDetailsPage.js
@@ -67,7 +67,7 @@ const SupplierInformationDetailsPage = (props) => {
     }
   });
 
-  if (['DRAFT'].indexOf(details.supplierInformation.validationStatus) < 0) {
+  if (['SAVED', 'UNSAVED'].indexOf(statuses.supplierInformation.status) < 0) {
     disabledCheckboxes = 'disabled';
     disabledInputs = true;
   }


### PR DESCRIPTION
- Make everything read-only when status is confirmed or submitted.
- created new method for retrieving the summary confirmation.
- fixed a bug with saving summary confirmation.