### PR TITLE
ZEVA-570:Change the logic for the effective dates for the the model year report

### DIFF
--- a/backend/api/viewsets/vehicle.py
+++ b/backend/api/viewsets/vehicle.py
@@ -108,8 +108,21 @@ class VehicleViewSet(
         organization_id = _request.user.organization.id
         org_submission = SalesSubmission.objects.filter(
             organization_id=organization_id)
-        from_date = (report_year-1, 10, 1,)
-        to_date = (report_year, 9, 30,)
+        from_date = None
+        to_date = None
+        from_date_str = None
+        to_date_str = None
+
+        if report_year == 2020:
+            from_date = (2018, 1, 2,)
+            to_date = (report_year + 1, 9, 30,)
+            from_date_str = "2018-01-02"
+            to_date_str = str(report_year + 1) + "-09-30"
+        else:
+            from_date = (report_year, 10, 1,)
+            to_date = (report_year + 1, 9, 30,)
+            from_date_str = str(report_year) + "-10-01"
+            to_date_str = str(report_year+1) + "-09-30"
 
         sales_from_date = xlrd.xldate.xldate_from_date_tuple(from_date, 0)
         sales_to_date = xlrd.xldate.xldate_from_date_tuple(to_date, 0)
@@ -123,8 +136,8 @@ class VehicleViewSet(
                 ~Q(xls_sale_date="")
             ) |
               Q(
-                Q(xls_sale_date__lte=str(report_year) + "-09-30") &
-                Q(xls_sale_date__gte=str(report_year-1) + "-10-01") &
+                Q(xls_sale_date__lte=to_date_str) &
+                Q(xls_sale_date__gte=from_date_str) &
                 Q(xls_date_type="1") &
                 ~Q(xls_sale_date="")
               )

--- a/frontend/src/compliance/ComplianceObligationContainer.js
+++ b/frontend/src/compliance/ComplianceObligationContainer.js
@@ -103,8 +103,9 @@ const ComplianceObligationContainer = (props) => {
         const creditDeficit = (remainingReduction - provisionalBalanceCurrentYearA);
         console.log('credit deficit', creditDeficit);
       }
+
       setZevClassAReduction({
-        lastYearA: formatNumeric((lastYearReduction), 2),
+        lastYearA: lastYearReduction,
         currentYearA: currentYearReduction,
       });
       setRemainingABalance({
@@ -198,16 +199,16 @@ const ComplianceObligationContainer = (props) => {
           unspecifiedZevClassLastYearA = lastYearABalance;
         }
       }
-      if (provisionalBalanceLastYearB === 0 && provisionalBalanceLastYearA > 0 && unspecifiedZevClassReduction >= provisionalBalanceLastYearA) {
-        unspecifiedZevClassLastYearA = provisionalBalanceLastYearA;
+      if (provisionalBalanceLastYearB === 0 && lastYearABalance >= 0 && unspecifiedZevClassReduction >= lastYearABalance) {
+        unspecifiedZevClassLastYearA = lastYearABalance;
       }
       // Reduce current year's B credits first then current year's A.
       remainingUnspecifiedReduction = unspecifiedZevClassReduction - (unspecifiedZevClassLastYearA + unspecifiedZevClassLastYearB);
       if (provisionalBalanceCurrentYearB > 0 && provisionalBalanceCurrentYearB >= remainingUnspecifiedReduction) {
         unspecifiedZevClassCurrentYearB = remainingUnspecifiedReduction;
       }
-      if (provisionalBalanceCurrentYearB === 0 && provisionalBalanceCurrentYearA > 0 && remainingUnspecifiedReduction >= provisionalBalanceCurrentYearA) {
-        unspecifiedZevClassCurrentYearA = provisionalBalanceCurrentYearA;
+      if (provisionalBalanceCurrentYearB === 0 && currentYearABalance >= 0 && remainingUnspecifiedReduction >= currentYearABalance) {
+        unspecifiedZevClassCurrentYearA = currentYearABalance;
       }
       if (provisionalBalanceCurrentYearB > 0 && provisionalBalanceCurrentYearB < remainingUnspecifiedReduction) {
         unspecifiedZevClassCurrentYearB = provisionalBalanceCurrentYearB;
@@ -216,7 +217,7 @@ const ComplianceObligationContainer = (props) => {
           unspecifiedZevClassCurrentYearA = unspecifieldBalance;
         }
         if (unspecifieldBalance > 0 && currentYearABalance > 0 && currentYearABalance < unspecifieldBalance) {
-          unspecifiedZevClassCurrentYearA = unspecifieldBalance - provisionalBalanceCurrentYearA;
+          unspecifiedZevClassCurrentYearA = unspecifieldBalance - currentYearABalance;
         }
       }
     }

--- a/frontend/src/compliance/components/ComplianceObligationTableCreditsIssued.js
+++ b/frontend/src/compliance/components/ComplianceObligationTableCreditsIssued.js
@@ -56,7 +56,7 @@ const ComplianceObligationTableCreditsIssued = (props) => {
       <tbody>
         <tr className="subclass">
           <th className="large-column">
-            BALANCE AT END OF SEPT. 30,  {reportYear - 1}
+            BALANCE AT END OF SEPT. 30,  {reportYear}
           </th>
           <th className="small-column text-center text-blue">
             A

--- a/frontend/src/compliance/components/SummaryCreditActivityTable.js
+++ b/frontend/src/compliance/components/SummaryCreditActivityTable.js
@@ -145,7 +145,7 @@ const SummaryCreditActivityTable = (props) => {
       <tbody>
         {tableSection(
           creditBalanceStart,
-          `Balance at end of September 30, ${year - 1} :`,
+          `Balance at end of September 30, ${year} :`,
         )}
         {/* {tableSection(
           creditBalanceStart,


### PR DESCRIPTION
- Change effective date logic for model year report 

  - updated vehicle sales dates for consumer sales page
  - updated compliance obligation backend logic dates

- Also, minor text changes

- found a bug in offset calculation, added a fix.