### PR TITLE
ZEVA 614 - prevent suppliers from skipping reports

### DIFF
--- a/frontend/src/compliance/ComplianceReportsContainer.js
+++ b/frontend/src/compliance/ComplianceReportsContainer.js
@@ -22,22 +22,58 @@ const ComplianceReportsContainer = (props) => {
     setLoading(showLoading);
     axios.get(ROUTES_COMPLIANCE.REPORTS).then((response) => {
       setData(response.data);
-      console.log(response.data);
       const allRecords = [];
       response.data.forEach((record) => {
         const status = record.validationStatus;
         const year = record.modelYear.name;
-        allRecords.push({ year: status });
+        allRecords.push({ year, status });
       });
+      // sort records by year
+      allRecords.sort((a, b) => parseFloat(a.year) - parseFloat(b.year));
+      // if validation status exists but is not assessed for one year
+      // do not add any further years to filtered years/available years
+      let unfinishedFlag = false;
+      const completedYears = [];
+      allRecords.every((record) => {
+        if (record.status !== 'ASSESSED') {
+          unfinishedFlag = true;
+          return false;
+        }
+        completedYears.push(record.year);
+        return true;
+      });
+      let filteredYears = [];
+      const mostRecentCompleted = completedYears.pop();
+      const nextYear = parseInt(mostRecentCompleted, 10) + 1;
+      if (availableYears.lenth > 0) {
+        // show only the next year if all previous reports have been assessed
+        filteredYears = availableYears.filter((year) => (
+          year === nextYear
+        ));
+      }
+      const { ldvSales } = user.organization;
+      if (ldvSales) {
+        // if an organization has ldv sales, only allow them to submit reports
+        // for the year after their most recent sale
+        ldvSales.sort((a, b) => parseFloat(a.modelYear) - parseFloat(b.modelYear));
+        const mostRecentSale = ldvSales.pop();
+        filteredYears = availableYears.filter((year) => (
+          year === parseInt(mostRecentSale.modelYear, 10) + 1
+        ));
+      } else {
+        // if an organization does not have ldv sales, only allow them to submit
+        // reports for the current year and previous year
+        const today = new Date();
+        const currentYear = today.getFullYear();
+        const previousYear = currentYear - 1;
+        filteredYears = availableYears.filter((year) => (
+          year === currentYear || year === previousYear
+        ));
+      }
 
-    //sort records by year
-    //if validation status exists but is not assessed for one year
-    // do not add any further years to filtered years/available years
-      const filteredYears = availableYears.filter((year) => (
-        response.data.findIndex(
-          (item) => parseInt(item.modelYear.name, 10) === parseInt(year, 10),
-        ) < 0
-      ));
+      if (unfinishedFlag) {
+        filteredYears = [];
+      }
       setAvailableYears(filteredYears);
       setLoading(false);
     });

--- a/frontend/src/compliance/ComplianceReportsContainer.js
+++ b/frontend/src/compliance/ComplianceReportsContainer.js
@@ -22,59 +22,63 @@ const ComplianceReportsContainer = (props) => {
     setLoading(showLoading);
     axios.get(ROUTES_COMPLIANCE.REPORTS).then((response) => {
       setData(response.data);
-      const allRecords = [];
-      response.data.forEach((record) => {
-        const status = record.validationStatus;
-        const year = record.modelYear.name;
-        allRecords.push({ year, status });
-      });
-      // sort records by year
-      allRecords.sort((a, b) => parseFloat(a.year) - parseFloat(b.year));
-      // if validation status exists but is not assessed for one year
-      // do not add any further years to filtered years/available years
-      let unfinishedFlag = false;
-      const completedYears = [];
-      allRecords.every((record) => {
-        if (record.status !== 'ASSESSED') {
-          unfinishedFlag = true;
-          return false;
-        }
-        completedYears.push(record.year);
-        return true;
-      });
-      let filteredYears = [];
-      const mostRecentCompleted = completedYears.pop();
-      const nextYear = parseInt(mostRecentCompleted, 10) + 1;
-      if (availableYears.lenth > 0) {
+      // if the user is a supplier, figure out which years to allow them to create reports for
+      if (!user.isGovernment) {
+        const allRecords = [];
+        response.data.forEach((record) => {
+          const status = record.validationStatus;
+          const year = record.modelYear.name;
+          allRecords.push({ year, status });
+        });
+        // sort records by year
+        allRecords.sort((a, b) => parseFloat(a.year) - parseFloat(b.year));
+        // if validation status exists but is not assessed for one year
+        // do not add any further years to filtered years/available years
+        let unfinishedFlag = false;
+        const completedYears = [];
+        allRecords.every((record) => {
+          if (record.status !== 'ASSESSED') {
+            unfinishedFlag = true;
+            return false;
+          }
+          completedYears.push(record.year);
+          return true;
+        });
+        let filteredYears = [];
+        const mostRecentCompleted = completedYears.pop();
+        const nextYear = parseInt(mostRecentCompleted, 10) + 1;
+        if (availableYears.length > 0) {
         // show only the next year if all previous reports have been assessed
-        filteredYears = availableYears.filter((year) => (
-          year === nextYear
-        ));
-      }
-      const { ldvSales } = user.organization;
-      if (ldvSales) {
-        // if an organization has ldv sales, only allow them to submit reports
-        // for the year after their most recent sale
-        ldvSales.sort((a, b) => parseFloat(a.modelYear) - parseFloat(b.modelYear));
-        const mostRecentSale = ldvSales.pop();
-        filteredYears = availableYears.filter((year) => (
-          year === parseInt(mostRecentSale.modelYear, 10) + 1
-        ));
-      } else {
-        // if an organization does not have ldv sales, only allow them to submit
-        // reports for the current year and previous year
-        const today = new Date();
-        const currentYear = today.getFullYear();
-        const previousYear = currentYear - 1;
-        filteredYears = availableYears.filter((year) => (
-          year === currentYear || year === previousYear
-        ));
-      }
+          filteredYears = availableYears.filter((year) => (
+            year === nextYear
+          ));
+        } else if (availableYears.length === 0) {
+          const { ldvSales } = user.organization;
+          if (ldvSales.length > 0) {
+            // if an organization has ldv sales, only allow them to submit reports
+            // for the year after their most recent sale
+            ldvSales.sort((a, b) => parseFloat(a.modelYear) - parseFloat(b.modelYear));
+            const mostRecentSale = ldvSales.pop();
+            filteredYears = availableYears.filter((year) => (
+              year === parseInt(mostRecentSale.modelYear, 10) + 1
+            ));
+          } else {
+            // if an organization does not have ldv sales, only allow them to submit
+            // reports for the current year and previous year
+            const today = new Date();
+            const currentYear = today.getFullYear();
+            const previousYear = currentYear - 1;
+            filteredYears = availableYears.filter((year) => (
+              year === currentYear || year === previousYear
+            ));
+          }
+        }
 
-      if (unfinishedFlag) {
-        filteredYears = [];
+        if (unfinishedFlag) {
+          filteredYears = [];
+        }
+        setAvailableYears(filteredYears);
       }
-      setAvailableYears(filteredYears);
       setLoading(false);
     });
   };

--- a/frontend/src/compliance/ComplianceReportsContainer.js
+++ b/frontend/src/compliance/ComplianceReportsContainer.js
@@ -22,6 +22,17 @@ const ComplianceReportsContainer = (props) => {
     setLoading(showLoading);
     axios.get(ROUTES_COMPLIANCE.REPORTS).then((response) => {
       setData(response.data);
+      console.log(response.data);
+      const allRecords = [];
+      response.data.forEach((record) => {
+        const status = record.validationStatus;
+        const year = record.modelYear.name;
+        allRecords.push({ year: status });
+      });
+
+    //sort records by year
+    //if validation status exists but is not assessed for one year
+    // do not add any further years to filtered years/available years
       const filteredYears = availableYears.filter((year) => (
         response.data.findIndex(
           (item) => parseInt(item.modelYear.name, 10) === parseInt(year, 10),


### PR DESCRIPTION
-limits suppliers to which reports can be created
  - if suppliers have unassessed reports, they cannot create any new ones
  - if suppliers have no reports, they can create a report based on the last year of sales they have 
  - OR if they have no sales they can create a report for current year or previous year