### PR TITLE
ZEVA 600 - Credit agreement feature - document upload

### DIFF
--- a/backend/api/serializers/credit_agreement.py
+++ b/backend/api/serializers/credit_agreement.py
@@ -6,8 +6,23 @@ from api.serializers.credit_agreement_content import \
     CreditAgreementContentSerializer
 from api.models.credit_agreement_statuses import CreditAgreementStatuses
 from api.models.credit_agreement_transaction_types import CreditAgreementTransactionTypes
+from api.models.user_profile import UserProfile
+from api.serializers.user import MemberSerializer
+from api.serializers.credit_agreement_attachment import CreditAgreementAttachmentSerializer
+from api.models.credit_agreement_attachment import CreditAgreementAttachment
 
-class CreditAgreementSerializer(ModelSerializer):
+class CreditAgreementBaseSerializer:
+    def get_update_user(self, obj):
+        user_profile = UserProfile.objects.filter(username=obj.update_user)
+
+        if user_profile.exists():
+            serializer = MemberSerializer(user_profile.first(), read_only=True)
+            return serializer.data
+
+        return obj.update_user
+
+
+class CreditAgreementSerializer(ModelSerializer, CreditAgreementBaseSerializer):
     organization = OrganizationSerializer(read_only=True)
 
     class Meta:
@@ -16,6 +31,15 @@ class CreditAgreementSerializer(ModelSerializer):
             'id', 'organization', 'effective_date', 'transaction_type',
         )
 
+
+class CreditAgreementTransactionTypeSerializer(ModelSerializer):
+    class Meta:
+        model = CreditAgreementTransactionTypes
+        fields = (
+            'transaction_type',
+        )
+
+
 class CreditAgreementSaveSerializer(ModelSerializer, EnumSupportSerializerMixin):
     status = EnumField(
         CreditAgreementStatuses,
@@ -23,6 +47,11 @@ class CreditAgreementSaveSerializer(ModelSerializer, EnumSupportSerializerMixin)
     )
     transaction_type = EnumField(
         CreditAgreementTransactionTypes,
+        required=False
+    )
+    agreement_attachments = CreditAgreementAttachmentSerializer(
+        allow_null=True,
+        many=True,
         required=False
     )
 
@@ -36,18 +65,69 @@ class CreditAgreementSaveSerializer(ModelSerializer, EnumSupportSerializerMixin)
         )
         return obj
 
+    def update(self, instance, validated_data):
+        status = validated_data.get('validation_status')
+        request = self.context.get('request')
+        agreement_attachments = validated_data.pop('agreement_attachments', [])
+        files_to_be_removed = request.data.get('delete_files', [])
+        credit_agreement_comment = validated_data.pop('agreement_comment', None)
+
+        if credit_agreement_comment:
+            CreditAgreementComment.objects.create(
+                create_user=request.user.username,
+                credit_agreement=instance,
+                comment=agreement_comment.get('comment')
+            )
+
+        for attachment in agreement_attachments:
+            CreditAgreementAttachment.objects.create(
+                create_user=request.user.username,
+                credit_agreement=instance,
+                **attachment
+            )
+
+        for file_id in files_to_be_removed:
+            attachment = CreditAgreementAttachment.objects.filter(
+                id=file_id,
+                credit_agreement=instance
+            ).first()
+
+            if attachment:
+                minio_remove_object(attachment.minio_object_name)
+
+                attachment.is_removed = True
+                attachment.update_user = request.user.username
+                attachment.save()
+
+        for data in validated_data:
+            setattr(instance, data, validated_data[data])
+
+            if data == 'make':
+                make = validated_data[data]
+                make = " ".join(make.upper().split())
+
+                setattr(instance, data, make)
+
+        instance.update_user = request.user.username
+        instance.save()
+
+        if status:
+            notifications_zev_model(instance, status)
+
+        return instance
+
     class Meta:
         model = CreditAgreement
         fields = (
             'create_timestamp', 'organization',  'effective_date', 'id',
-            'update_user', 'status', 'transaction_type'
+            'update_user', 'status', 'transaction_type', 'agreement_attachments'
         )
 
 
 class CreditAgreementListSerializer(
-        ModelSerializer, EnumSupportSerializerMixin,
+        ModelSerializer, EnumSupportSerializerMixin, CreditAgreementBaseSerializer
 ):
-    history = SerializerMethodField()
+    # history = SerializerMethodField()
     organization = OrganizationSerializer()
     credit_agreement_content = CreditAgreementContentSerializer(
         many=True, read_only=True

--- a/backend/api/viewsets/credit_agreement.py
+++ b/backend/api/viewsets/credit_agreement.py
@@ -21,9 +21,9 @@ class CreditAgreementViewSet(
     http_method_names = ['get', 'post', 'put', 'patch']
     queryset = CreditAgreement.objects.all()
     serializer_classes = {
-        'default': CreditAgreementListSerializer,
+        'default': CreditAgreementSerializer,
         'create': CreditAgreementSaveSerializer,
-
+        'partial_update': CreditAgreementSaveSerializer,
     }
 
     def get_serializer_class(self):

--- a/frontend/src/creditagreements/CreditAgreementsEditContainer.js
+++ b/frontend/src/creditagreements/CreditAgreementsEditContainer.js
@@ -56,7 +56,6 @@ const CreditAgreementsEditContainer = (props) => {
   const handleUpload = (paramId) => {
     const promises = [];
     // setShowProgressBars(true);
-
     files.forEach((file, index) => {
       promises.push(new Promise((resolve, reject) => {
         const reader = new FileReader();
@@ -116,10 +115,24 @@ const CreditAgreementsEditContainer = (props) => {
   };
   const handleSubmit = () => {
     const data = { organization: agreementDetails.vehicleSupplier, agreementDetails };
-    axios.post(ROUTES_CREDIT_AGREEMENTS.LIST, data).then(
+    axios.post(ROUTES_CREDIT_AGREEMENTS.LIST, data).then((response) => {
       // after agreement is created, then post the content using the id from the response
-      () => { console.log('!'); },
-    );
+      const { id: agreementId } = response.data;
+      const uploadPromises = handleUpload(agreementId);
+      Promise.all(uploadPromises).then((attachments) => {
+        const patchData = {};
+        if (attachments.length > 0) {
+          patchData.agreementAttachments = attachments;
+        }
+        axios.patch(ROUTES_CREDIT_AGREEMENTS.DETAILS.replace(/:id/gi, agreementId), {
+          ...patchData,
+        }).then(() => {
+            console.log('SUCCESS! no details page built yet');
+
+        //   history.push(ROUTES_CREDIT_AGREEMENTS.DETAILS.replace(/:id/gi, agreementId));
+        });
+      });
+    });
   };
   const refreshDetails = () => {
     const yearsPromise = axios.get(ROUTES_VEHICLES.YEARS);

--- a/frontend/src/creditagreements/components/CreditAgreementsForm.js
+++ b/frontend/src/creditagreements/components/CreditAgreementsForm.js
@@ -75,17 +75,6 @@ const CreditAgreementsForm = (props) => {
                     maxFiles={5}
                   />
                 </div>
-
-                <div className="col-12 text-right pt-3">
-                  <button
-                    disabled={files.length === 0}
-                    className="button primary"
-                    onClick={() => { console.log(files); upload(); }}
-                    type="button"
-                  >
-                    <FontAwesomeIcon icon="upload" /> Upload
-                  </button>
-                </div>
                 <div className="form-group mt-4 row">
                   <div className="col-12 text-blue">
                     <strong>Files</strong> (doc, docx, xls, xlsx, pdf, jpg, png)

--- a/frontend/src/creditagreements/components/CreditAgreementsForm.js
+++ b/frontend/src/creditagreements/components/CreditAgreementsForm.js
@@ -40,7 +40,6 @@ const CreditAgreementsForm = (props) => {
     years,
     handleDeleteRow,
   } = props;
-  console.log(files);
   return (
     <div id="credit-agreements-form" className="page">
       <div className="row mt-3 mb-2">


### PR DESCRIPTION
- adds update function in save serializer for adding attachment
-starts adding some other base serializers such as get update user
-removes history.push after agreement attachment upload and instead console logs (details page not built)

-document is uploaded when agreement is submitted NOT when upload button is clicked