### PR TITLE
Zeva487 - add model year report to dashboard

### DIFF
--- a/backend/api/serializers/dashboard.py
+++ b/backend/api/serializers/dashboard.py
@@ -1,0 +1,31 @@
+"""
+Account Balance Serializer
+"""
+from rest_framework.serializers import ModelSerializer, SerializerMethodField
+
+from api.models.model_year_report import ModelYearReport
+from api.serializers.credit_transaction import CreditClassSerializer
+from api.serializers.user import MemberSerializer
+from api.models.organization import Organization
+from api.models.model_year_report_statuses import ModelYearReportStatuses
+
+class DashboardListSerializer(ModelSerializer):
+    """
+    Serializer for dashboard model year report
+    """
+
+    model_year_report_validation_status = SerializerMethodField()
+
+    
+    def get_model_year_report_validation_status(self, obj):
+        request = self.context.get('request')
+        if not request.user.is_government and obj.validation_status is ModelYearReportStatuses.RECOMMENDED:
+            return ModelYearReportStatuses.SUBMITTED.value
+        return obj.get_validation_status_display()
+
+
+    class Meta:
+        model = ModelYearReport
+        fields = (
+            'id', 'model_year_report_validation_status'
+        )

--- a/backend/api/urls.py
+++ b/backend/api/urls.py
@@ -16,6 +16,7 @@ from .viewsets.upload import UploadViewSet
 from .viewsets.model_year_report_consumer_sales import ModelYearReportConsumerSalesViewSet
 from .viewsets.model_year_report_compliance_obligation import ModelYearReportComplianceObligationViewset
 from .viewsets.credit_agreement import CreditAgreementViewSet
+from .viewsets.dashboard import DashboardViewset
 
 
 router = routers.SimpleRouter(trailing_slash=False)
@@ -56,6 +57,9 @@ router.register(
 )
 router.register(
     r'credit-agreements', CreditAgreementViewSet, basename='credit-agreement'
+)
+router.register(
+    r'dashboard/list', DashboardViewset, basename='list'
 )
 
 urlpatterns = router.urls

--- a/backend/api/viewsets/dashboard.py
+++ b/backend/api/viewsets/dashboard.py
@@ -1,0 +1,33 @@
+from rest_framework import mixins, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
+from api.models.user_profile import UserProfile
+from api.permissions.user import UserPermissions
+from api.models.model_year_report import ModelYearReport
+from api.serializers.dashboard import DashboardListSerializer
+from auditable.views import AuditableMixin
+
+
+class DashboardViewset(
+        AuditableMixin, viewsets.GenericViewSet,
+        mixins.CreateModelMixin, mixins.ListModelMixin,
+        mixins.UpdateModelMixin, mixins.RetrieveModelMixin
+):
+    """
+    This viewset automatically provides `list`, `create`, `retrieve`,
+    and  `update`  actions.
+    """
+    permission_classes = (UserPermissions,)
+    http_method_names = ['get']
+    queryset = ModelYearReport.objects.all()
+
+    serializer_classes = {
+        'default': DashboardListSerializer,
+        'list': DashboardListSerializer
+    }
+
+    def get_serializer_class(self):
+        if self.action in list(self.serializer_classes.keys()):
+            return self.serializer_classes[self.action]
+
+        return self.serializer_classes['default']

--- a/frontend/src/app/routes/Dashboard.js
+++ b/frontend/src/app/routes/Dashboard.js
@@ -1,0 +1,7 @@
+const API_BASE_PATH = '/dashboard';
+
+const DASHBOARD = {
+  LIST: `${API_BASE_PATH}/list`,
+};
+
+export default DASHBOARD;

--- a/frontend/src/compliance/ComplianceReportsContainer.js
+++ b/frontend/src/compliance/ComplianceReportsContainer.js
@@ -1,25 +1,39 @@
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
-
+import { withRouter } from 'react-router';
 import CONFIG from '../app/config';
 import CustomPropTypes from '../app/utilities/props';
 import ComplianceTabs from '../app/components/ComplianceTabs';
 import ROUTES_COMPLIANCE from '../app/routes/Compliance';
 import ComplianceReportListPage from './components/ComplianceReportListPage';
 
+const qs = require('qs');
+
 const ComplianceReportsContainer = (props) => {
-  const { user } = props;
+  const { location, user } = props;
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState([]);
   const [collapsed, setCollapsed] = useState(true);
+  const [filtered, setFiltered] = useState([]);
   const [availableYears, setAvailableYears] = useState(CONFIG.FEATURES.MODEL_YEAR_REPORT.YEARS);
+
+  const query = qs.parse(location.search, { ignoreQueryPrefix: true });
 
   const collapseDropdown = () => {
     setCollapsed(!collapsed);
   };
 
   const refreshList = (showLoading) => {
+
     setLoading(showLoading);
+    const queryFilter = [];
+    Object.entries(query).forEach(([key, value]) => {
+      queryFilter.push({ id: key, value });
+    });
+    setFiltered([...filtered, ...queryFilter]);
+    if (location.state) {
+      setFiltered([...filtered, ...location.state]);
+    }
     axios.get(ROUTES_COMPLIANCE.REPORTS).then((response) => {
       setData(response.data);
       // if the user is a supplier, figure out which years to allow them to create reports for
@@ -103,6 +117,8 @@ const ComplianceReportsContainer = (props) => {
         loading={loading}
         user={user}
         showSupplier={user.isGovernment}
+        filtered={filtered}
+        setFiltered={setFiltered}
       />
     </>
   );
@@ -110,4 +126,4 @@ const ComplianceReportsContainer = (props) => {
 ComplianceReportsContainer.propTypes = {
   user: CustomPropTypes.user.isRequired,
 };
-export default ComplianceReportsContainer;
+export default withRouter(ComplianceReportsContainer);

--- a/frontend/src/compliance/components/ComplianceReportListPage.js
+++ b/frontend/src/compliance/components/ComplianceReportListPage.js
@@ -18,6 +18,8 @@ const ComplianceReportListPage = (props) => {
     collapseDropdown,
     availableYears,
     showSupplier,
+    filtered,
+    setFiltered,
   } = props;
 
   if (loading) {
@@ -92,7 +94,13 @@ const ComplianceReportListPage = (props) => {
       )}
       <div className="row mt-4">
         <div className="col-sm-12">
-          <ComplianceReportsTable data={data} user={user} showSupplier={showSupplier} />
+          <ComplianceReportsTable
+            data={data}
+            user={user}
+            showSupplier={showSupplier}
+            filtered={filtered}
+            setFiltered={setFiltered}
+          />
         </div>
       </div>
     </div>

--- a/frontend/src/compliance/components/ComplianceReportsTable.js
+++ b/frontend/src/compliance/components/ComplianceReportsTable.js
@@ -8,7 +8,7 @@ import ROUTES_COMPLIANCE from '../../app/routes/Compliance';
 import formatNumeric from '../../app/utilities/formatNumeric';
 
 const ComplianceReportsTable = (props) => {
-  const { user, data, showSupplier } = props;
+  const { user, data, showSupplier, filtered, setFiltered } = props;
 
   const supplierClass = (paramClass) => {
     if (paramClass === 'L') {
@@ -91,6 +91,8 @@ const ComplianceReportsTable = (props) => {
       columns={columns}
       data={data}
       filterable
+      filtered={filtered}
+      setFiltered={setFiltered}
       getTrProps={(state, row) => {
         if (row && row.original && user) {
           return {

--- a/frontend/src/dashboard/DashboardContainer.js
+++ b/frontend/src/dashboard/DashboardContainer.js
@@ -11,6 +11,7 @@ import DashboardPage from './components/DashboardPage';
 import ROUTES_CREDIT_REQUESTS from '../app/routes/CreditRequests';
 import ROUTES_VEHICLES from '../app/routes/Vehicles';
 import ROUTES_CREDIT_TRANSFERS from '../app/routes/CreditTransfers';
+import ROUTES_DASHBOARD from '../app/routes/Dashboard';
 
 const DashboardContainer = (props) => {
   const { user } = props;
@@ -29,6 +30,11 @@ const DashboardContainer = (props) => {
     transfersRecorded: 0,
     transfersRejectedByPartner: 0,
     transfersRejected: 0,
+    reportsDraft: 0,
+    reportsSubmitted: 0,
+    reportsAnalyst: 0,
+    reportsAssessed: 0,
+    reportsRecommended: 0,
   });
 
   const [loading, setLoading] = useState(true);
@@ -111,6 +117,22 @@ const DashboardContainer = (props) => {
       }
     })
   );
+  const getModelYearReports = () => (
+    axios.get(ROUTES_DASHBOARD.LIST).then((dashboardResponse) => {
+      if (!user.isGovernment) {
+        const reportsDraft = dashboardResponse.data.filter((report) => report.modelYearReportValidationStatus === 'DRAFT');
+        const reportsSubmitted = dashboardResponse.data.filter((report) => report.modelYearReportValidationStatus === 'SUBMITTED');
+        activityCount = {...activityCount,
+          reportsDraft: reportsDraft.length,
+          reportsSubmitted: reportsSubmitted.length}
+      } else {
+        const reportsAnalyst = dashboardResponse.data.filter((report) => report.modelYearReportValidationStatus === 'SUBMITTED');
+        activityCount = { ...activityCount,
+          reportsAnalyst: reportsAnalyst.length }
+      }
+      console.log(dashboardResponse.data);
+    })
+  );
 
   const getCreditTransfers = () => (
     axios.get(ROUTES_CREDIT_TRANSFERS.LIST).then((transfersResponse) => {
@@ -159,7 +181,7 @@ const DashboardContainer = (props) => {
 
   const refreshList = () => {
     const promises = [];
-
+    promises.push(getModelYearReports())
     if (user.hasPermission('VIEW_SALES')) {
       promises.push(getCreditRequests());
     }

--- a/frontend/src/dashboard/DashboardContainer.js
+++ b/frontend/src/dashboard/DashboardContainer.js
@@ -119,18 +119,21 @@ const DashboardContainer = (props) => {
   );
   const getModelYearReports = () => (
     axios.get(ROUTES_DASHBOARD.LIST).then((dashboardResponse) => {
+
       if (!user.isGovernment) {
         const reportsDraft = dashboardResponse.data.filter((report) => report.modelYearReportValidationStatus === 'DRAFT');
         const reportsSubmitted = dashboardResponse.data.filter((report) => report.modelYearReportValidationStatus === 'SUBMITTED');
+        const reportsAssessed = dashboardResponse.data.filter((report) => report.modelYearReportValidationStatus === 'ASSESSED');
         activityCount = {...activityCount,
           reportsDraft: reportsDraft.length,
-          reportsSubmitted: reportsSubmitted.length}
+          reportsSubmitted: reportsSubmitted.length,
+          reportsAssessed: reportsAssessed.length,
+        };
       } else {
         const reportsAnalyst = dashboardResponse.data.filter((report) => report.modelYearReportValidationStatus === 'SUBMITTED');
         activityCount = { ...activityCount,
           reportsAnalyst: reportsAnalyst.length }
       }
-      console.log(dashboardResponse.data);
     })
   );
 

--- a/frontend/src/dashboard/components/ActionsBceid.js
+++ b/frontend/src/dashboard/components/ActionsBceid.js
@@ -203,7 +203,7 @@ const ActionsBceid = (props) => {
         && (
         <ActivityBanner
           colour="yellow"
-          icon="exchange-alt"
+          icon="file-alt"
           boldText="Model Year Report"
           regularText={`${activityCount.reportsDraft} awaiting submission`}
           linkTo={`${ROUTES_COMPLIANCE.REPORTS}?status=Draft`}
@@ -215,7 +215,7 @@ const ActionsBceid = (props) => {
         && (
         <ActivityBanner
           colour="blue"
-          icon="exchange-alt"
+          icon="file-alt"
           boldText="Model Year Report"
           regularText={`${activityCount.reportsSubmitted} awaiting government assessment`}
           linkTo={`${ROUTES_COMPLIANCE.REPORTS}?status=Submitted`}
@@ -227,7 +227,7 @@ const ActionsBceid = (props) => {
         && (
         <ActivityBanner
           colour="green"
-          icon="exchange-alt"
+          icon="file-alt"
           boldText="Model Year Report"
           regularText={`${activityCount.reportsAssessed} assessed by government`}
           linkTo={`${ROUTES_COMPLIANCE.REPORTS}?status=Assessed`}

--- a/frontend/src/dashboard/components/ActionsBceid.js
+++ b/frontend/src/dashboard/components/ActionsBceid.js
@@ -199,14 +199,38 @@ const ActionsBceid = (props) => {
         )}
         {CONFIG.FEATURES.MODEL_YEAR_REPORT.ENABLED
         && activityCount.reportsDraft > 0
-        && user.hasPermission('VIEW_COMPLIANCE_REPORTS')
+        && user.hasPermission('SUBMIT_COMPLIANCE_REPORT')
         && (
         <ActivityBanner
           colour="yellow"
           icon="exchange-alt"
           boldText="Model Year Report"
           regularText={`${activityCount.reportsDraft} awaiting submission`}
-          linkTo={`${ROUTES_COMPLIANCE.REPORT_SUPPLIER_INFORMATION}?status=Draft`}
+          linkTo={`${ROUTES_COMPLIANCE.REPORTS}?status=Draft`}
+        />
+        )}
+        {CONFIG.FEATURES.MODEL_YEAR_REPORT.ENABLED
+        && activityCount.reportsSubmitted > 0
+        && user.hasPermission('SUBMIT_COMPLIANCE_REPORT')
+        && (
+        <ActivityBanner
+          colour="blue"
+          icon="exchange-alt"
+          boldText="Model Year Report"
+          regularText={`${activityCount.reportsSubmitted} awaiting government assessment`}
+          linkTo={`${ROUTES_COMPLIANCE.REPORTS}?status=Submitted`}
+        />
+        )}
+        {CONFIG.FEATURES.MODEL_YEAR_REPORT.ENABLED
+        && activityCount.reportsAssessed > 0
+        && user.hasPermission('SUBMIT_COMPLIANCE_REPORT')
+        && (
+        <ActivityBanner
+          colour="green"
+          icon="exchange-alt"
+          boldText="Model Year Report"
+          regularText={`${activityCount.reportsAssessed} assessed by government`}
+          linkTo={`${ROUTES_COMPLIANCE.REPORTS}?status=Assessed`}
         />
         )}
       </div>

--- a/frontend/src/dashboard/components/ActionsBceid.js
+++ b/frontend/src/dashboard/components/ActionsBceid.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Loading from '../../app/components/Loading';
 import ActivityBanner from './ActivityBanner';
 import ROUTES_VEHICLES from '../../app/routes/Vehicles';
+import ROUTES_COMPLIANCE from '../../app/routes/Compliance';
 import ROUTES_CREDIT_REQUESTS from '../../app/routes/CreditRequests';
 import ROUTES_CREDIT_TRANSFERS from '../../app/routes/CreditTransfers';
 import CONFIG from '../../app/config';
@@ -194,6 +195,18 @@ const ActionsBceid = (props) => {
           boldText="Credit Transfer"
           regularText={`${activityCount.transfersRejected} rejected by Government of B.C.`}
           linkTo={`${ROUTES_CREDIT_TRANSFERS.LIST}?status=Rejected By Government`}
+        />
+        )}
+        {CONFIG.FEATURES.MODEL_YEAR_REPORT.ENABLED
+        && activityCount.reportsDraft > 0
+        && user.hasPermission('VIEW_COMPLIANCE_REPORTS')
+        && (
+        <ActivityBanner
+          colour="yellow"
+          icon="exchange-alt"
+          boldText="Model Year Report"
+          regularText={`${activityCount.reportsDraft} awaiting submission`}
+          linkTo={`${ROUTES_COMPLIANCE.REPORT_SUPPLIER_INFORMATION}?status=Draft`}
         />
         )}
       </div>

--- a/frontend/src/dashboard/components/ActionsIdir.js
+++ b/frontend/src/dashboard/components/ActionsIdir.js
@@ -15,7 +15,7 @@ const ActionsIdir = (props) => {
   if (loading) {
     return <Loading />;
   }
-  console.log(activityCount)
+  console.log(activityCount);
   return (
     <div id="actions" className="dashboard-card">
       <div className="content">
@@ -137,10 +137,36 @@ const ActionsIdir = (props) => {
         && (
         <ActivityBanner
           colour="yellow"
-          icon="exchange-alt"
-          boldText="Model Year Report"
+          icon="file-alt"
+          boldText="Model Year Reports"
           regularText={`${activityCount.reportsAnalyst} require analyst/engineer review`}
-          linkTo={`${ROUTES_COMPLIANCE.REPORT_SUPPLIER_INFORMATION}?status=Submitted`}
+          linkTo={`${ROUTES_COMPLIANCE.REPORTS}?status=Submitted`}
+        />
+        )}
+        {CONFIG.FEATURES.MODEL_YEAR_REPORT.ENABLED
+        && ((user.hasPermission('RECOMMEND_COMPLIANCE_REPORT')
+        && activityCount.reportsAnalyst === 0)
+        || (!user.hasPermission('RECOMMEND_COMPLIANCE_REPORT') && activityCount.reportsDirector === 0)
+        )
+        && (
+        <ActivityBanner
+          colour="green"
+          icon="file-alt"
+          boldText="Model Year Reports"
+          regularText="no current activity"
+          linkTo={ROUTES_COMPLIANCE.REPORTS}
+        />
+        )}
+        {CONFIG.FEATURES.MODEL_YEAR_REPORT.ENABLED
+        && user.hasPermission('SIGN_COMPLIANCE_REPORT')
+        && activityCount.reportsDirector > 0
+        && (
+        <ActivityBanner
+          colour="blue"
+          icon="file-alt"
+          boldText="Model Year Reports"
+          regularText={`${activityCount.reportsAnalyst} recommended for director action`}
+          linkTo={`${ROUTES_COMPLIANCE.REPORTS}?status=Recommended`}
         />
         )}
       </div>

--- a/frontend/src/dashboard/components/ActionsIdir.js
+++ b/frontend/src/dashboard/components/ActionsIdir.js
@@ -15,7 +15,6 @@ const ActionsIdir = (props) => {
   if (loading) {
     return <Loading />;
   }
-  console.log(activityCount);
   return (
     <div id="actions" className="dashboard-card">
       <div className="content">

--- a/frontend/src/dashboard/components/ActionsIdir.js
+++ b/frontend/src/dashboard/components/ActionsIdir.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import ROUTES_COMPLIANCE from '../../app/routes/Compliance';
 import ROUTES_CREDIT_REQUESTS from '../../app/routes/CreditRequests';
 import ROUTES_CREDIT_TRANSFERS from '../../app/routes/CreditTransfers';
 import ROUTES_VEHICLES from '../../app/routes/Vehicles';
@@ -15,6 +15,7 @@ const ActionsIdir = (props) => {
   if (loading) {
     return <Loading />;
   }
+  console.log(activityCount)
   return (
     <div id="actions" className="dashboard-card">
       <div className="content">
@@ -129,6 +130,18 @@ const ActionsIdir = (props) => {
             regularText="no current activity"
             linkTo={ROUTES_CREDIT_TRANSFERS.LIST}
           />
+        )}
+        {CONFIG.FEATURES.MODEL_YEAR_REPORT.ENABLED
+        && activityCount.reportsAnalyst > 0
+        && user.hasPermission('RECOMMEND_COMPLIANCE_REPORT')
+        && (
+        <ActivityBanner
+          colour="yellow"
+          icon="exchange-alt"
+          boldText="Model Year Report"
+          regularText={`${activityCount.reportsAnalyst} require analyst/engineer review`}
+          linkTo={`${ROUTES_COMPLIANCE.REPORT_SUPPLIER_INFORMATION}?status=Submitted`}
+        />
         )}
       </div>
     </div>


### PR DESCRIPTION
-adds url, viewset and serializer for retrieving dashboard data
-adds model year report to new serializer
-adds model year report activities to dashboard frontend
-adds filtering ability to model year report container (so the list can be filtered when activity banner is clicked)