### PR TITLE
BugFix - 7,8,9,10

### DIFF
--- a/frontend/src/compliance/ComplianceObligationContainer.js
+++ b/frontend/src/compliance/ComplianceObligationContainer.js
@@ -87,21 +87,19 @@ const ComplianceObligationContainer = (props) => {
 
       setUnspecifiedReductions(tempUnspecifiedReductions);
 
-      if (creditReductionSelection) {
-        const creditReduction = calculateCreditReduction(
-          balances,
-          tempClassAReductions,
-          tempUnspecifiedReductions,
-          creditReductionSelection,
-        );
+      const creditReduction = calculateCreditReduction(
+        balances,
+        tempClassAReductions,
+        tempUnspecifiedReductions,
+        creditReductionSelection,
+      );
 
-        setDeductions(creditReduction.deductions);
+      setDeductions(creditReduction.deductions);
 
-        setUpdatedBalances({
-          balances: creditReduction.balances,
-          deficits: creditReduction.deficits,
-        });
-      }
+      setUpdatedBalances({
+        balances: creditReduction.balances,
+        deficits: creditReduction.deficits,
+      });
     }
   };
 
@@ -286,8 +284,10 @@ const ComplianceObligationContainer = (props) => {
         administrativeReduction,
         automaticAdministrativePenalty
       } = getComplianceObligationDetails(complianceResponseDetails);
-
-      setPendingBalanceExist(tempPendingBalanceExist);
+    
+      if (pendingBalance) {
+        setPendingBalanceExist(true);
+      }
 
       setReportDetails({
         creditBalanceStart,

--- a/frontend/src/compliance/components/ComplianceObligationReductionOffsetTable.js
+++ b/frontend/src/compliance/components/ComplianceObligationReductionOffsetTable.js
@@ -173,7 +173,7 @@ const ComplianceObligationReductionOffsetTable = (props) => {
             <table className="col-12">
               <tbody>
                 <tr className="subclass">
-                  <th className="large-column">Provisional Balance after Credit Reduction</th>
+                  <th className="large-column">PROVISIONAL BALANCE AFTER CREDIT REDUCTION</th>
                   <th className="small-column text-center text-blue">A</th>
                   <th className="small-column text-center text-blue">B</th>
                 </tr>

--- a/frontend/src/compliance/components/ComplianceObligationReductionOffsetTable.js
+++ b/frontend/src/compliance/components/ComplianceObligationReductionOffsetTable.js
@@ -35,6 +35,9 @@ const ComplianceObligationReductionOffsetTable = (props) => {
                       <th className="small-column text-center text-blue">A</th>
                       <th className="small-column text-center text-blue">B</th>
                     </tr>
+                    {deductions.length == 0 &&
+                      <tr><td>&nbsp;</td></tr>
+                    }
                     {deductions.filter((deduction) => deduction.type === 'classAReduction').map((deduction) => (
                       <tr key={deduction.modelYear}>
                         <td className="text-blue">

--- a/frontend/src/compliance/components/ComplianceObligationTableCreditsIssued.js
+++ b/frontend/src/compliance/components/ComplianceObligationTableCreditsIssued.js
@@ -154,7 +154,7 @@ const ComplianceObligationTableCreditsIssued = (props) => {
         <tbody>
           <tr className="subclass">
             <th className="large-column">
-              {pendingBalanceExist ? 'Provisional Balance Before Credit Reduction' : 'Balance Before Credit Reduction'}
+              {pendingBalanceExist ? 'PROVISIONAL BALANCE BEFORE CREDIT REDUCTION' : 'BALANCE BEFORE CREDIT REDUCTION'}
             </th>
             <th className="small-column text-center text-blue">A</th>
             <th className="small-column text-center text-blue">B</th>


### PR DESCRIPTION
**7.** Added blank line after Credit A Reduction heading if there is no reduction data present
**8.** Inconsistency in the behavior for what happens when the user changes LDV sales number. Sometimes the A credit reduction changes without saving and other times the user has to save first - **removed the condition to calculate reduction only if credit reduction selection is there inside onchangeLdvSales function. Now user can see reduction numbers changing without saving ldvSales first**
**9.** The text for all types of balances is all caps
**10.** The unspecified credit reduction appears to default to B without the user selecting either radio button. As a result the user can currently progress to finalize the report without selecting A or B.- **added condition, radioId should be present before calculation of unspecified reduction.**