### PR TITLE
ZEVA-702:Bug: Save Button and Curly Braces showing up in the Details screen (supplmentary reports)

### DIFF
--- a/backend/api/serializers/model_year_report_supplemental.py
+++ b/backend/api/serializers/model_year_report_supplemental.py
@@ -191,7 +191,6 @@ class SupplementalReportAssessmentSerializer(
         request = self.context.get('request')
         assessment_comment = SupplementalReportAssessmentComment.objects.filter(
             supplemental_report_id=obj
-
         ).order_by('-create_timestamp')
         if not request.user.is_government:
             assessment_comment = SupplementalReportAssessmentComment.objects.filter(

--- a/backend/api/viewsets/model_year_report.py
+++ b/backend/api/viewsets/model_year_report.py
@@ -561,12 +561,11 @@ class ModelYearReportViewset(
                 return HttpResponse(status=200)
 
             if validation_status:
-                if validation_status == 'RECOMMENDED' and analyst_action:
-                    if not description:
-                    # returning a 200 to bypass the rest of the update
-                        return HttpResponse(
-                            status=200, content="Recommendation is required"
-                        )
+                if validation_status == 'RECOMMENDED' and analyst_action and not description:
+                   # returning a 200 to bypass the rest of the update
+                    return HttpResponse(
+                        status=200, content="Recommendation is required"
+                    )
 
                 report.supplemental.status = validation_status
                 report.supplemental.update_user = request.user.username

--- a/backend/api/viewsets/model_year_report.py
+++ b/backend/api/viewsets/model_year_report.py
@@ -532,6 +532,7 @@ class ModelYearReportViewset(
         report = get_object_or_404(ModelYearReport, pk=pk)
         validation_status = request.data.get('status')
         description = request.data.get('description')
+        analyst_action = request.data.get('analyst_action',None)
 
         create_user = None
         supplemental_id = None
@@ -560,18 +561,19 @@ class ModelYearReportViewset(
                 return HttpResponse(status=200)
 
             if validation_status:
-                if validation_status == 'RECOMMENDED' and not description:
+                if validation_status == 'RECOMMENDED' and analyst_action:
+                    if not description:
                     # returning a 200 to bypass the rest of the update
-                    return HttpResponse(
-                        status=200, content="Recommendation is required"
-                    )
+                        return HttpResponse(
+                            status=200, content="Recommendation is required"
+                        )
 
                 report.supplemental.status = validation_status
                 report.supplemental.update_user = request.user.username
                 report.supplemental.save()
 
                 # check for if validation status is recommended
-                if validation_status == 'RECOMMENDED' or \
+                if validation_status == 'RECOMMENDED' and analyst_action or \
                         (validation_status == 'SUBMITTED' and description):
                     # do "update or create" to create the assessment object
                     penalty = request.data.get('penalty')

--- a/frontend/src/supplementary/SupplementaryContainer.js
+++ b/frontend/src/supplementary/SupplementaryContainer.js
@@ -225,6 +225,7 @@ const SupplementaryContainer = (props) => {
           fromSupplierComment: comment,
         };
         if (analystAction) {
+          data.analystAction = true;
           data.penalty = supplementaryAssessmentData.supplementaryAssessment.assessmentPenalty;
           data.description = supplementaryAssessmentData.supplementaryAssessment.decision.id;
         }

--- a/frontend/src/supplementary/components/SupplementaryDetailsPage.js
+++ b/frontend/src/supplementary/components/SupplementaryDetailsPage.js
@@ -94,7 +94,8 @@ const SupplementaryDetailsPage = (props) => {
       <label className="d-inline text-blue" htmlFor="complied">
         {each.description
           .replace(/{user.organization.name}/g, details.assessmentData.legalName)
-          .replace(/{modelYear}/g, details.assessmentData.modelYear)}
+          .replace(/{modelYear}/g, details.assessmentData.modelYear)
+          .replace(/{penalty}/g, `$${formattedPenalty} CAD`)}
       </label>
       )}
     </div>
@@ -415,7 +416,7 @@ const SupplementaryDetailsPage = (props) => {
             </span>
             <span className="right-content">
               {CONFIG.FEATURES.SUPPLEMENTAL_REPORT.ENABLED
-              && ((!user.isGovernment && currentStatus === 'DRAFT')
+              && ((currentStatus === 'DRAFT')
               || ((currentStatus === 'SUBMITTED' || currentStatus === 'RECOMMENDED') && user.isGovernment)) && (
               <Button
                 buttonType="save"


### PR DESCRIPTION
- fixed curly braces showing up instead of the intended value in the penalty descriptions
- Save button is visible now  when reassessment is in draft
- save button is visible to director when status is recommended so that they can edit/save the supplier comment
- Assessment descriptions are showing up now after it's been recommended
- (Fixed) Clicking on save on a Recommended Supplementary tries to redirect to an undefined report