### PR TITLE
ZEVA-696:General bugs/enhancements & changes

### DIFF
--- a/backend/api/viewsets/model_year_report.py
+++ b/backend/api/viewsets/model_year_report.py
@@ -92,7 +92,7 @@ class ModelYearReportViewset(
         if request.user.organization.is_government:
             queryset = ModelYearReport.objects.exclude(validation_status=(
                 ModelYearReportStatuses.DRAFT
-            ))
+            )).order_by('-model_year')
 
             organization_id = request.query_params.get('organization_id', None)
 
@@ -101,7 +101,7 @@ class ModelYearReportViewset(
         else:
             queryset = ModelYearReport.objects.filter(
                 organization_id=request.user.organization.id
-            )
+            ).order_by('-model_year')
 
         return queryset
 

--- a/frontend/src/compliance/ConsumerSalesContainer.js
+++ b/frontend/src/compliance/ConsumerSalesContainer.js
@@ -18,6 +18,7 @@ const ConsumerSalesContainer = (props) => {
   const [vehicles, setVehicles] = useState([]);
   const [assertions, setAssertions] = useState([]);
   const [confirmed, setConfirmed] = useState(false);
+  const [checked, setChecked] = useState(false);
   const [checkboxes, setCheckboxes] = useState([]);
   const [disabledCheckboxes, setDisabledCheckboxes] = useState('');
   const [modelYear, setModelYear] = useState(CONFIG.FEATURES.MODEL_YEAR_REPORT.DEFAULT_YEAR);
@@ -96,11 +97,13 @@ const ConsumerSalesContainer = (props) => {
         (each) => Number(each) !== Number(event.target.id),
       );
       setCheckboxes(checked);
+      setChecked(false);
     }
 
     if (event.target.checked) {
       const checked = checkboxes.concat(event.target.id);
       setCheckboxes(checked);
+      setChecked(true);
     }
   };
 
@@ -147,6 +150,7 @@ const ConsumerSalesContainer = (props) => {
         errorMessage={errorMessage}
         id={id}
         handleCancelConfirmation={handleCancelConfirmation}
+        checked={checked}
       />
     </>
   );

--- a/frontend/src/compliance/components/ComplianceCalculatorDetailsInputs.js
+++ b/frontend/src/compliance/components/ComplianceCalculatorDetailsInputs.js
@@ -41,7 +41,7 @@ const ComplianceCalculatorDetailsInputs = (props) => {
               htmlFor="supplier-size"
               className="pl-3 col-form-label"
             >
-              Supplier Size
+              Supplier Class
             </label>
             &nbsp; (based on average of previous 3 year total LDV sale):
           </div>

--- a/frontend/src/compliance/components/ComplianceObligationDetailsPage.js
+++ b/frontend/src/compliance/components/ComplianceObligationDetailsPage.js
@@ -74,7 +74,7 @@ const ComplianceObligationDetailsPage = (props) => {
 
   if (!creditReductionSelection) {
     disabledCheckboxes = 'disabled';
-    hoverText = 'You must select a ZEV class credit preference for your Unspecified ZEV Class Credit Reduction';
+    hoverText = 'You must enter a LDV Sales Total and select a ZEV class credit preference for your Unspecified ZEV Class Credit Reduction';
   }
 
   if (loading) {

--- a/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
+++ b/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
@@ -25,6 +25,7 @@ const ConsumerSalesDetailsPage = (props) => {
     modelYear,
     statuses,
     id,
+    checked
   } = props;
 
   const [showModal, setShowModal] = useState(false);
@@ -69,6 +70,13 @@ const ConsumerSalesDetailsPage = (props) => {
       disabledCheckboxes = 'disabled';
     }
   });
+
+  const disableSave = () => {
+    if (vehicles.length <= 0 && !checked) {
+       return true;
+    }
+    return false;
+  }
 
   return (
     <div id="compliance-consumer-sales-details" className="page">
@@ -173,9 +181,9 @@ const ConsumerSalesDetailsPage = (props) => {
                 <Button
                   buttonType="save"
                   disabled={
-                    ['SAVED', 'UNSAVED'].indexOf(
-                      statuses.consumerSales.status,
-                    ) < 0
+                    (['SAVED', 'UNSAVED'].indexOf(
+                    statuses.consumerSales.status,
+                    ) < 0) || disableSave()
                   }
                   optionalClassname="button primary"
                   action={(event) => {

--- a/frontend/src/users/components/UserDetailsForm.js
+++ b/frontend/src/users/components/UserDetailsForm.js
@@ -108,7 +108,7 @@ const UserDetailsForm = (props) => {
                     errorMessage={'username' in errorFields && errorFields.username}
                     handleInputChange={handleInputChange}
                     id="username"
-                    label={`${accountType} User Name`}
+                    label={`${accountType} User Id`}
                     mandatory
                     name="username"
                   />


### PR DESCRIPTION
- order model year report list in desc order in the backend
- On consumer sales page, disable save button if there are no sales record and when confirmation checkbox is not checked.
- added a tooltip text to enter LDV sales total on compliance obligation before clicking confirmation checkbox
- update text supplier size to supplier class on calculator page
- change label from bceid User Name to User Id on admin page.