### PR TITLE
ZEVA- 703 to release-1.31.0

### DIFF
--- a/backend/api/viewsets/model_year_report.py
+++ b/backend/api/viewsets/model_year_report.py
@@ -535,6 +535,7 @@ class ModelYearReportViewset(
         analyst_action = request.data.get('analyst_action',None)
         new_report = request.data.get('new_report', None)
 
+
         create_user = None
         supplemental_id = None
 
@@ -586,6 +587,7 @@ class ModelYearReportViewset(
                             'penalty': penalty
                         }
                     )
+
             if new_report:
                 serializer = ModelYearReportSupplementalSerializer(
                 data=request.data

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeva-frontend",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "private": true,
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",

--- a/frontend/src/compliance/components/AssessmentDetailsPage.js
+++ b/frontend/src/compliance/components/AssessmentDetailsPage.js
@@ -189,6 +189,7 @@ const AssessmentDetailsPage = (props) => {
                 className="btn button primary float-right"
                 onClick={() => {
                   history.push(ROUTES_SUPPLEMENTARY.CREATE.replace(/:id/g, id), {new:true});
+
                 }}
                 type="button"
               >

--- a/frontend/src/compliance/components/ComplianceHistory.js
+++ b/frontend/src/compliance/components/ComplianceHistory.js
@@ -31,6 +31,7 @@ const ComplianceHistory = (props) => {
     return `Supplementary report signed and submitted to the Government of B.C. ${moment(item.updateTimestamp).format('MMM D, YYYY')} by ${item.updateUser}`;
   };
   const recommendedText = (item) => `Supplementary report recommended ${moment(item.updateTimestamp).format('MMM D, YYYY')} by ${item.updateUser}`;
+
   const getSupersededStatus = (idx) => {
     if (noaHistory.supplemental && noaHistory.supplemental.length > 0 && idx == noaHistory.supplemental.length - 1 && noaHistory.supplemental[idx].status === 'ASSESSED') {
       displaySuperseded = false;
@@ -40,6 +41,7 @@ const ComplianceHistory = (props) => {
     }
     return displaySuperseded;
   }
+  
   const getLinkByStatus = (item) => {
     if (item.status === 'DRAFT') {
       if (Number(item.supplementalReportId) === Number(supplementaryId)) {

--- a/frontend/src/supplementary/SupplementaryContainer.js
+++ b/frontend/src/supplementary/SupplementaryContainer.js
@@ -228,6 +228,7 @@ const SupplementaryContainer = (props) => {
           deleteFiles,
           fromSupplierComment: comment,
         };
+
         if((status == 'RECOMMENDED' || status == 'DRAFT') && paramNewReport){
           data.newReport = paramNewReport;
         }


### PR DESCRIPTION
- A new line for Notice of Reassessment should show up if the Supplementary Report has been Assessed
- If a new supplementary report has been created then it should indent after the Notice of Reassessment for the supplementary report
- Add a condition for the Superseded text to only show up if the Model Year report has a supplementary report
- Notice of Reassessment, that's not the first line, should be clickable. (It should load the supplementary report it relates to)
- if bceid creates a draft supplementary report, it shows up as superseded (even to idir users who cant see the draft)
- Add a Superseded for the Supplementary Notice of Reassessment if there's a new supplementary report created for it.