### PR TITLE
Zeva694 - supplementary report statuses

### DIFF
--- a/backend/api/serializers/model_year_report.py
+++ b/backend/api/serializers/model_year_report.py
@@ -15,8 +15,10 @@ from api.models.model_year_report_statuses import ModelYearReportStatuses
 from api.serializers.model_year_report_ldv_sales import ModelYearReportLDVSalesSerializer
 from api.models.user_profile import UserProfile
 from api.models.model_year_report_assessment import ModelYearReportAssessment
+from api.models.supplemental_report import SupplementalReport
 from api.serializers.model_year_report_address import \
     ModelYearReportAddressSerializer
+
 from api.serializers.model_year_report_make import \
     ModelYearReportMakeSerializer
 from api.serializers.model_year_report_history import \
@@ -209,6 +211,9 @@ class ModelYearReportListSerializer(
     obligation_total = SerializerMethodField()
     obligation_credits = SerializerMethodField()
     ldv_sales = SerializerMethodField()
+    supplemental_status = SerializerMethodField()
+
+
 
     def get_ldv_sales(self, obj):
         return obj.ldv_sales
@@ -247,12 +252,79 @@ class ModelYearReportListSerializer(
             return ModelYearReportStatuses.SUBMITTED.value
         return obj.get_validation_status_display()
 
+    def get_supplemental_status(self, obj):
+        request = self.context.get('request')
+        supplemental_records = SupplementalReport.objects.filter(
+            model_year_report=obj
+        ).order_by('-create_timestamp')
+        supplemental_record = 0
+        if supplemental_records:
+            supplemental_record = supplemental_records[0]
+        if supplemental_record:
+            # get information on who created the record
+            create_user = UserProfile.objects.get(
+                username=supplemental_record.create_user
+            )
+            sup_status = supplemental_record.status.value
+            if create_user.is_government:
+                if sup_status == 'RETURNED':
+                    # this record was created by idir but 
+                    # should show up as supplementary returned
+                    return ('SUPPLEMENTARY {}').format(sup_status)
+                if sup_status == 'REASSESSED' or sup_status == 'ASSESSED':
+                    # bceid and idir can see just 'reassessed' as status
+                    return 'REASSESSED'
+                if request.user.is_government and sup_status in ['DRAFT', 'RECOMMENDED']:
+                    # created by idir and viewed by idir, they can see 
+                    # draft or recommended status
+                    return ('REASSESSMENT {}').format(sup_status)
+                if not request.user.is_government and sup_status in ['SUBMITTED', 'DRAFT', 'RECOMMENDED']:
+                    # if it is being viewed by bceid, they shouldnt see it
+                    # unless it is reassessed or returned
+                    if supplemental_records.count() > 1:
+                        for each in supplemental_records:
+                            # find the newest record that is either created by bceid or one that they are allowed to see
+                            item_create_user = UserProfile.objects.get(username=each.create_user)
+                            # bceid are allowed to see any created by them or
+                            # if the status is REASSESSED or RETURNED?
+                            if not item_create_user.is_government or each.status.value == 'RETURNED':
+                                return ('SUPPLEMENTARY {}').format(each.status.value)
+                            if each.status.value == 'REASSESSED':
+                                return each.status.value
+            else:
+                # if created by bceid its a supplemental report
+                if sup_status == 'SUBMITTED':
+                    return('SUPPLEMENTARY {}').format(sup_status)
+                if sup_status == 'DRAFT':
+                    if not request.user.is_government:
+                        return('SUPPLEMENTARY {}').format(sup_status)
+                    else:
+                        # same logic for bceid to check if theres another record
+                        if supplemental_records.count() > 1:
+                            for each in supplemental_records:
+                                # find the newest record that is either
+                                # created by bceid or they are able to see
+                                item_create_user = UserProfile.objects.get(username=each.create_user)
+                                # they are allowed to see any created by idir
+                                # or if it is submitted
+                                if item.create_user.is_government:
+                                    return ('REASSESSMENT {}').format(each.status.value)
+                                if each.status.value == 'SUBMITTED':
+                                    return ('SUPPLEMENTARY {}').format(each.status.value)
+        
+        # no supplemental report, just return the status from the assessment
+        if not request.user.is_government and obj.validation_status in [
+                ModelYearReportStatuses.RECOMMENDED,
+                ModelYearReportStatuses.RETURNED]:
+            return ModelYearReportStatuses.SUBMITTED.value
+        return obj.get_validation_status_display()
+    
     class Meta:
         model = ModelYearReport
         fields = (
             'id', 'organization_name', 'model_year', 'validation_status', 'ldv_sales',
             'supplier_class', 'compliant', 'obligation_total',
-            'obligation_credits',
+            'obligation_credits', 'supplemental_status'
         )
 
 

--- a/backend/api/tests/test_model_year_report_status.py
+++ b/backend/api/tests/test_model_year_report_status.py
@@ -1,0 +1,44 @@
+# from django.utils.datetime_safe import datetime
+# from rest_framework.serializers import ValidationError
+
+# from .base_test_case import BaseTestCase
+# from ..models.model_year_report import ModelYearReport
+# from ..models.supplemental_report import SupplementalReport
+# from ..models.model_year_report_statuses import ModelYearReportStatuses
+# from ..models.organization import Organization
+# from ..models.model_year import ModelYear
+
+
+# class TestModelYearReports(BaseTestCase):
+#     def setUp(self):
+#         super().setUp()
+
+#         org1 = self.users['EMHILLIE_BCEID'].organization
+#         gov = self.users['RTAN'].organization
+
+#         model_year_report = ModelYearReport.objects.create(
+#             organization=org1,
+#             create_user='EMHILLIE_BCEID',
+#             validation_status=ModelYearReportStatuses.ASSESSED,
+#             organization_name=Organization.objects.get('BMW Canada Inc.'),
+#             supplier_class='M',
+#             model_year=ModelYear.objects.get('2021'),
+#             credit_reduction_selection='A'
+#         )
+#         supplementary_report = SupplementalReport.objects.create(
+#             create_user='EMHILLIE_BCEID',
+#             validation_status=ModelYearReportStatuses.DRAFT,
+#         )
+#         reassessment_report = SupplementalReport.objects.create(
+#             create_user='RTAN',
+#             validation_status=ModelYearReportStatuses.DRAFT,
+#         )
+
+#     def test_status(self):
+#         response = self.clients['EMHILLIE_BCEID'].get("/api/compliance/reports")
+#         self.assertEqual(response.status_code, 200)
+#         result = response.data
+#         print('(((((((((())))))))))')
+#         print(result)
+#         print('(((((((((())))))))))')
+#         # self.assertEqual(len(result), 1)

--- a/frontend/src/compliance/ComplianceReportsContainer.js
+++ b/frontend/src/compliance/ComplianceReportsContainer.js
@@ -32,7 +32,6 @@ const ComplianceReportsContainer = (props) => {
     }
     const ratiosPromise = axios.get(ROUTES_COMPLIANCE.RATIOS);
     const reportsPromise = axios.get(ROUTES_COMPLIANCE.REPORTS);
-    
 
     Promise.all([reportsPromise, ratiosPromise]).then(
       ([response, ratiosResponse]) => {

--- a/frontend/src/compliance/ComplianceReportsContainer.js
+++ b/frontend/src/compliance/ComplianceReportsContainer.js
@@ -32,6 +32,7 @@ const ComplianceReportsContainer = (props) => {
     }
     const ratiosPromise = axios.get(ROUTES_COMPLIANCE.RATIOS);
     const reportsPromise = axios.get(ROUTES_COMPLIANCE.REPORTS);
+    
 
     Promise.all([reportsPromise, ratiosPromise]).then(
       ([response, ratiosResponse]) => {

--- a/frontend/src/compliance/components/AssessmentDetailsPage.js
+++ b/frontend/src/compliance/components/AssessmentDetailsPage.js
@@ -188,12 +188,11 @@ const AssessmentDetailsPage = (props) => {
               <button
                 className="btn button primary float-right"
                 onClick={() => {
-                  history.push(ROUTES_SUPPLEMENTARY.CREATE.replace(/:id/g, id), {new:true});
-
+                  history.push(ROUTES_SUPPLEMENTARY.CREATE.replace(/:id/g, id), { new: true });
                 }}
                 type="button"
               >
-                Create Supplemental Report
+                Create Supplementary Report
               </button>
             )}
             {CONFIG.FEATURES.SUPPLEMENTAL_REPORT.ENABLED
@@ -201,7 +200,7 @@ const AssessmentDetailsPage = (props) => {
               <button
                 className="btn button primary float-right"
                 onClick={() => {
-                  history.push(ROUTES_SUPPLEMENTARY.REASSESSMENT.replace(/:id/g, id), {new:true});
+                  history.push(ROUTES_SUPPLEMENTARY.REASSESSMENT.replace(/:id/g, id), { new: true });
                 }}
                 type="button"
               >

--- a/frontend/src/compliance/components/ComplianceReportsTable.js
+++ b/frontend/src/compliance/components/ComplianceReportsTable.js
@@ -8,6 +8,7 @@ import ROUTES_COMPLIANCE from '../../app/routes/Compliance';
 import formatNumeric from '../../app/utilities/formatNumeric';
 import getClassAReduction from '../../app/utilities/getClassAReduction';
 import getTotalReduction from '../../app/utilities/getTotalReduction';
+import formatStatus from '../../app/utilities/formatStatus';
 
 const ComplianceReportsTable = (props) => {
   const {
@@ -83,8 +84,8 @@ const ComplianceReportsTable = (props) => {
     id: 'model-year',
     maxWidth: 260,
   }, {
-    accessor: (item) => (item.validationStatus),
-    className: 'text-center',
+    accessor: (row) => (formatStatus(row.supplementalStatus)),
+    className: 'text-center text-capitalize',
     Header: 'Status',
     headerClassName: 'font-weight-bold',
     id: 'status',


### PR DESCRIPTION
-adds logic for displaying statuses on model year report index

if viewer is bceid they should see:
   'Reassessed' if it is reassessed
   'Returned' if it is returned
   'Supplementary Submitted' - if a supplementary report has been submitted and if any further idir actions are not viewable by bceid ie there is a reassessment report in draft or recommended
   'Supplementary Draft' if they have saved a draft


if the viewer is idir they should see:
   'Reassessed' if it is reassessed
   'Supplementary Submitted' - if a supplementary report has been submitted and idir has not done anything else
   'Reassessment Draft' if they have saved a draft
   'Reassessment recommended'

Not sure if idir users see returned status, it is not listed in the card but i did include it in this pr


pr also includes the start of some tests that i will work on later