### PR TITLE
partial zeva 708 - supplementary draft saved by bceid remove modal popup

### DIFF
--- a/frontend/src/supplementary/SupplementaryContainer.js
+++ b/frontend/src/supplementary/SupplementaryContainer.js
@@ -39,7 +39,6 @@ const SupplementaryContainer = (props) => {
   && user.hasPermission('SIGN_COMPLIANCE_REPORT');
 
   const isReassessment = reassessment && user.isGovernment && user.hasPermission('RECOMMEND_COMPLIANCE_REPORT');
-
   const calculateBalance = (creditActivity) => {
     const balances = {};
 


### PR DESCRIPTION
- changes 'current status' to draft if the previous status was assessed and its a new report
-adds condition to check if user.isgovernent before showing reassessment modal

-if user is not government and saves it just saves a draft

fixed vscode warning about mixing || and && operators, took a guess on where to add brackets
