### PR TITLE
fix: ZEVA 414 - missing dashboard alert for Recommended Model Year Reports

### DIFF
--- a/backend/api/serializers/dashboard.py
+++ b/backend/api/serializers/dashboard.py
@@ -112,10 +112,15 @@ class DashboardListSerializer(ModelSerializer):
                 organization_id=request.user.organization_id)
             report_statuses = []
             for each in model_year_reports:
-                
-                supplemental_report = each.get_latest_supplemental(request)
-                if supplemental_report:
-                    report_statuses.append(supplemental_report.status.value)
+                # supplemental_report = each.get_latest_supplemental(request)
+                # if supplemental_report:
+                #     if supplemental_report.status.value == 'RECOMMENDED':
+                #         report_statuses.append('SUBMITTED')
+                #     else:
+                #         report_statuses.append(supplemental_report.status.value)
+                # else:
+                if each.validation_status in [ ModelYearReportStatuses.RECOMMENDED, ModelYearReportStatuses.RETURNED]:
+                    report_statuses.append('SUBMITTED')
                 else:
                     report_statuses.append(each.validation_status.value)
             status_dict = {}

--- a/backend/api/serializers/dashboard.py
+++ b/backend/api/serializers/dashboard.py
@@ -112,17 +112,17 @@ class DashboardListSerializer(ModelSerializer):
                 organization_id=request.user.organization_id)
             report_statuses = []
             for each in model_year_reports:
-                # supplemental_report = each.get_latest_supplemental(request)
-                # if supplemental_report:
-                #     if supplemental_report.status.value == 'RECOMMENDED':
-                #         report_statuses.append('SUBMITTED')
-                #     else:
-                #         report_statuses.append(supplemental_report.status.value)
-                # else:
-                if each.validation_status in [ ModelYearReportStatuses.RECOMMENDED, ModelYearReportStatuses.RETURNED]:
-                    report_statuses.append('SUBMITTED')
+                supplemental_report = each.get_latest_supplemental(request)
+                if supplemental_report:
+                    if supplemental_report.status.value == 'RECOMMENDED':
+                        report_statuses.append('SUBMITTED')
+                    else:
+                        report_statuses.append(supplemental_report.status.value)
                 else:
-                    report_statuses.append(each.validation_status.value)
+                    if each.validation_status in [ ModelYearReportStatuses.RECOMMENDED, ModelYearReportStatuses.RETURNED]:
+                        report_statuses.append('SUBMITTED')
+                    else:
+                        report_statuses.append(each.validation_status.value)
             status_dict = {}
             for i in report_statuses:
                 if i in status_dict:


### PR DESCRIPTION
Returns recommended status model year reports as 'submitted' to bceid users so it will show up on dashboard. 
Comments out logic for supplemental reports because for now we don't need to/can't see supplemental reports