### PR TITLE
fix: ZEVA 420 - IDIR analyst return MY report to suppler, set all tabs to draft/unchecked 

### DIFF
--- a/backend/api/serializers/model_year_report.py
+++ b/backend/api/serializers/model_year_report.py
@@ -464,11 +464,17 @@ class ModelYearReportSaveSerializer(
 
         if delete_confirmations:
             module = request.data.get('module', None)
-            ModelYearReportConfirmation.objects.filter(
-                model_year_report=instance,
-                signing_authority_assertion__module=module
-            ).delete()
-
+            if isinstance(module, list):
+                for each in module:
+                    ModelYearReportConfirmation.objects.filter(
+                        model_year_report=instance,
+                        signing_authority_assertion__module=each
+                        ).delete()
+            else:
+                ModelYearReportConfirmation.objects.filter(
+                    model_year_report=instance,
+                    signing_authority_assertion__module=module
+                ).delete()
             return instance
 
         makes = validated_data.pop('makes')

--- a/frontend/src/compliance/AssessmentContainer.js
+++ b/frontend/src/compliance/AssessmentContainer.js
@@ -54,6 +54,24 @@ const AssessmentContainer = (props) => {
   const handleCommentChangeBceid = (text) => {
     setBceidComment(text);
   };
+  const handleCancelConfirmation = () => {
+    const data = {
+      delete_confirmations: true,
+      module: [
+        'consumer_sales',
+        'compliance_obligation',
+        'supplier_information',
+        'compliance_summary'
+      ]
+    };
+
+    axios
+      .patch(ROUTES_COMPLIANCE.REPORT_DETAILS.replace(/:id/g, id), data)
+      .then((response) => {
+        history.push(ROUTES_COMPLIANCE.REPORTS);
+        history.replace(ROUTES_COMPLIANCE.REPORT_SUMMARY.replace(':id', id));
+      });
+  };
 
   const handleAddIdirComment = () => {
     const comment = { comment: idirComment, director: true };
@@ -513,6 +531,7 @@ const AssessmentContainer = (props) => {
         supplementaryStatus={supplementaryStatus}
         supplementaryId={supplementaryId}
         createdByGov={createdByGov}
+        handleCancelConfirmation={handleCancelConfirmation}
       />
     </>
   );

--- a/frontend/src/compliance/components/AssessmentDetailsPage.js
+++ b/frontend/src/compliance/components/AssessmentDetailsPage.js
@@ -49,7 +49,8 @@ const AssessmentDetailsPage = (props) => {
     updatedBalances,
     supplementaryStatus,
     supplementaryId,
-    createdByGov
+    createdByGov,
+    handleCancelConfirmation
   } = props;
 
   const [showModal, setShowModal] = useState(false);
@@ -58,6 +59,7 @@ const AssessmentDetailsPage = (props) => {
     details.assessment.assessmentPenalty,
     0
   );
+
   const assessmentDecision =
     details.assessment.decision && details.assessment.decision.description
       ? details.assessment.decision.description
@@ -77,6 +79,7 @@ const AssessmentDetailsPage = (props) => {
       handleSubmit={() => {
         setShowModal(false);
         handleSubmit('DRAFT');
+        handleCancelConfirmation();
       }}
       modalClass="w-75"
       showModal={showModal}


### PR DESCRIPTION
fix: adds cancelConfirmation function to return to supplier button, which passes a list of all modules to the backend. On the backend it iterates through the list and deletes the corresponding confirmations from the database.