### PR TITLE
Fix: ZEVA 402 - Credit application rejection - comments not visible to supplier (or idir)

### DIFF
--- a/backend/api/serializers/sales_submission.py
+++ b/backend/api/serializers/sales_submission.py
@@ -438,7 +438,7 @@ class SalesSubmissionSerializer(
         else:
             sales_submission_comment = SalesSubmissionComment.objects.filter(
                 sales_submission=obj,
-                to_govt=True
+                to_govt=False
             ).order_by('-create_timestamp')
 
         if sales_submission_comment.exists():

--- a/frontend/src/credits/components/CreditRequestDetailsPage.js
+++ b/frontend/src/credits/components/CreditRequestDetailsPage.js
@@ -67,13 +67,14 @@ const CreditRequestDetailsPage = (props) => {
 
   let modalProps = {};
 
-  const transferCommentsIDIR =
+  const submissionCommentsIdirOnly =
     submission &&
     submission.salesSubmissionComment &&
     submission.salesSubmissionComment
       .filter((each) => each.toGovt == true && each.comment)
       .map((item) => item);
-  const transferCommentsSupplier =
+
+  const submissionCommentsToSupplier =
     submission &&
     submission.salesSubmissionComment &&
     submission.salesSubmissionComment
@@ -82,7 +83,6 @@ const CreditRequestDetailsPage = (props) => {
   const handleCommentChange = (content) => {
     setComment(content);
   };
-
   const analystToSupplier = (
     <div>
       <label className="mt-3" htmlFor="reject-comment">
@@ -339,20 +339,31 @@ const CreditRequestDetailsPage = (props) => {
                 }
                 invalidSubmission={invalidSubmission}
               />
-              {((transferCommentsIDIR && transferCommentsIDIR.length > 0) ||
-                (transferCommentsSupplier &&
-                  transferCommentsSupplier.length > 0) ||
+
+              {((submissionCommentsIdirOnly &&
+                submissionCommentsIdirOnly.length > 0) ||
+                (submissionCommentsToSupplier &&
+                  submissionCommentsToSupplier.length > 0) ||
                 user.isGovernment) && (
                 <div className="comment-box mt-2">
-                  {transferCommentsIDIR &&
-                    transferCommentsIDIR.length > 0 &&
+                  {submissionCommentsIdirOnly &&
+                    submissionCommentsIdirOnly.length > 0 &&
                     user.isGovernment && (
-                      <DisplayComment commentArray={transferCommentsIDIR} />
+                      <>
+                        <b>Internal Comments</b>
+                        <DisplayComment
+                          commentArray={submissionCommentsIdirOnly}
+                        />
+                      </>
                     )}
-                  {transferCommentsSupplier &&
-                    transferCommentsSupplier.length > 0 &&
-                    !user.isGovernment && (
-                      <DisplayComment commentArray={transferCommentsSupplier} />
+                  {submissionCommentsToSupplier &&
+                    submissionCommentsToSupplier.length > 0 && (
+                      <>
+                        <b>Comments to Supplier</b>
+                        <DisplayComment
+                          commentArray={submissionCommentsToSupplier}
+                        />
+                      </>
                     )}
                   {((analystAction && validatedOnly) || directorAction) &&
                     idirCommentSection}


### PR DESCRIPTION
fix: - updates sales submission comment serializer, switches to_govt flag to false in filter for bceid users so they only receive comments that are NOT meant for internal users
-removes !isGovernment in condition for displaying comments to supplier (idir users should see their own comments)
- changes variable names for comment arrays in frontend from transferCommentsIdir etc to submissionCommentsIdirOnly so its more clear what the comments are and who they are meant for -adds bold headers to comment arrays so idir users can see which comments are which
<img width="896" alt="Screen Shot 2022-09-08 at 10 32 11 AM" src="https://user-images.githubusercontent.com/44536222/189187990-0ed0b00f-7ef5-4fc0-8a2b-310a1c0c2364.png">
