### PR TITLE
fix: zeva 446 - remove return to analyst button from analyst view on supplementary report

### DIFF
--- a/frontend/src/supplementary/components/SupplementaryDetailsPage.js
+++ b/frontend/src/supplementary/components/SupplementaryDetailsPage.js
@@ -676,11 +676,14 @@ const SupplementaryDetailsPage = (props) => {
                 (isEditable ||
                   ['SUBMITTED', 'RECOMMENDED'].indexOf(details.status) >= 0) &&
                 user.isGovernment &&
-                ((currentStatus === 'SUBMITTED' &&
+                (((currentStatus === 'SUBMITTED' ||
+                  currentStatus === 'RETURNED') &&
+                  analystAction &&
                   details &&
                   details.reassessment &&
                   !details.reassessment.isReassessment) ||
                   (currentStatus === 'RECOMMENDED' &&
+                    directorAction &&
                     details &&
                     details.reassessment &&
                     details.reassessment.isReassessment)) && (
@@ -695,7 +698,8 @@ const SupplementaryDetailsPage = (props) => {
                     }}
                     type="button"
                   >
-                    {currentStatus === 'SUBMITTED'
+                    {currentStatus === 'SUBMITTED' ||
+                    currentStatus === 'RETURNED'
                       ? 'Return to Vehicle Supplier'
                       : 'Return to Analyst'}
                   </button>


### PR DESCRIPTION
fix: adds directorAction into condition for displaying 'return to analyst' button


if user is an analyst and the status is either 'submitted' or 'returned' the analyst may click the button to return the report to the supplier

if the user is a director and the status is 'recommended' they may click the button to return the report to the analyst