### PR TITLE
fix: Zeva 443 - 21 error on old submissions

### DIFF
--- a/backend/api/models/sales_submission_content.py
+++ b/backend/api/models/sales_submission_content.py
@@ -84,7 +84,10 @@ class SalesSubmissionContent(Auditable):
 
     @property
     def icbc_verification(self):
-        q = 'select * from icbc_registration_data where vin=\'{}\' limit 1'.format(self.xls_vin)
+        q = 'select * from icbc_registration_data join icbc_upload_date on \
+            icbc_upload_date.id = icbc_upload_date_id where \
+                vin=\'{}\' and upload_date < \'{}\' limit 1'.format(
+                    self.xls_vin, self.update_timestamp)
         registration = IcbcRegistrationData.objects.raw(q)
         if registration:
             return registration[0]
@@ -114,7 +117,7 @@ class SalesSubmissionContent(Auditable):
         ).filter(
             vin=self.xls_vin
         ).exclude(
-            update_timestamp__gte=self.update_timestamp
+            create_timestamp__gte=self.update_timestamp
         ).first()
 
         if has_been_awarded:

--- a/backend/api/models/sales_submission_content.py
+++ b/backend/api/models/sales_submission_content.py
@@ -113,7 +113,7 @@ class SalesSubmissionContent(Auditable):
             submission_id=self.submission_id
         ).filter(
             vin=self.xls_vin
-        ).first()
+        ).exclude(update_timestamp__gte=self.update_timestamp).first()
 
         if has_been_awarded:
             return True

--- a/backend/api/models/sales_submission_content.py
+++ b/backend/api/models/sales_submission_content.py
@@ -113,7 +113,9 @@ class SalesSubmissionContent(Auditable):
             submission_id=self.submission_id
         ).filter(
             vin=self.xls_vin
-        ).exclude(update_timestamp__gte=self.update_timestamp).first()
+        ).exclude(
+            update_timestamp__gte=self.update_timestamp
+        ).first()
 
         if has_been_awarded:
             return True


### PR DESCRIPTION
reduces erroneous 21 errors
- adds a condition on the filter that removes any records where the submission timestamp is later than the timestamp of the current submission. This way, anything that comes through later than the current submission does not affect the calculated field. 