### PR TITLE
Fix: Added sortable prop to custom react table, removed sorting from credit tables - ZEVA 466

### DIFF
--- a/frontend/src/app/components/ReactTable.js
+++ b/frontend/src/app/components/ReactTable.js
@@ -61,6 +61,7 @@ class CustomReactTable extends Component {
       data,
       defaultSorted,
       filterable,
+      sortable,
       filtered,
       getTrProps,
       onFilteredChange,
@@ -73,6 +74,7 @@ class CustomReactTable extends Component {
         className={`searchable ${className}`}
         columns={columns}
         filtered={filtered}
+        sortable={sortable}
         data={data}
         defaultFilterMethod={CustomReactTable.defaultFilterMethod}
         defaultPageSize={this.defaultPageSize}

--- a/frontend/src/app/css/Credits.scss
+++ b/frontend/src/app/css/Credits.scss
@@ -505,6 +505,7 @@
       .rt-th {
         background-color: $default-background-grey;
         border-top: none;
+        box-shadow: inset 0 0 0 0 rgb(0 0 0);
       }
     }
 

--- a/frontend/src/credits/components/CreditBalanceTable.js
+++ b/frontend/src/credits/components/CreditBalanceTable.js
@@ -91,6 +91,7 @@ const CreditBalanceTable = (props) => {
     <ReactTable
       className="credit-balance-table"
       columns={columns}
+      sortable={false}
       data={Object.entries(balances)
         .map(([key, value]) => ({
           label: key,

--- a/frontend/src/credits/components/CreditTransactionListTable.js
+++ b/frontend/src/credits/components/CreditTransactionListTable.js
@@ -304,6 +304,7 @@ const CreditTransactionListTable = (props) => {
           desc: false
         }
       ]}
+      sortable={false}
       filterable={false}
       getTrProps={(state, row) => {
         if (row && row.original) {


### PR DESCRIPTION
credit balance and credit transaction tables are no longer sortable to retain the correct date order. Also removed the sorting styling to match.