### PR TITLE
Feat: Setting supplier inactive disables all supplier users - ZEVA 465

### DIFF
--- a/backend/api/serializers/organization.py
+++ b/backend/api/serializers/organization.py
@@ -96,6 +96,14 @@ class OrganizationSaveSerializer(serializers.ModelSerializer):
         is_active = validated_data.get('is_active')
         name = validated_data.get('name')
 
+        # disable all supplier users when we
+        # deactivate the organization
+        if obj.is_active and not is_active:
+            members = obj.members
+            for member in members:
+                member.is_active = False
+                member.save()
+
         obj.short_name = short_name
         obj.is_active = is_active
         obj.name = name

--- a/frontend/src/app/__tests__/router.test.js
+++ b/frontend/src/app/__tests__/router.test.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render, cleanup, findByTestId } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Router from '../router';
+import axios from 'axios';
+
+afterEach(cleanup);
+
+jest.mock('axios');
+
+const successfulResponse = {
+  data: {
+    id: 1,
+    displayName: "Tester 1",
+    email: "test@gov.bc.ca",
+    firstName: "Tester",
+    lastName: "1",
+    isActive: true,
+    isGovernment: true,
+    keycloakEmail: "test@gov.bc.ca",
+    organization: {
+      avgLdvSales: null,
+      balance: { A: 0, B: 0 },
+      createTimestamp: "2022-10-11T10:44:53.087843-07:00",
+      hasSubmittedReport: false,
+      id: 1,
+      isActive: true,
+      isGovernment: true,
+      ldvSales: [],
+      name: "Government of British Columbia",
+      organizationAddress: [],
+      shortName: null,
+      supplierClass: "S"
+    }
+  }
+}
+const dashboardResponse = { 
+  data: 
+  [
+    { 
+      activity: { 
+        vehicle: { name: 'test' },
+        creditAgreement: [{ agreement: { status: 'test' } }],
+      },
+    }
+  ] 
+}
+const failedResponse = { detail: 'failed verification' }
+
+axios.get
+.mockImplementationOnce(() => Promise.resolve(successfulResponse))
+.mockImplementationOnce(() => Promise.resolve(dashboardResponse))
+.mockImplementation(() => Promise.reject(failedResponse))
+.mockImplementation(() => Promise.reject(failedResponse))
+
+describe('Router Success', () => {
+  const keycloak = {};
+  const logout = jest.fn();
+
+  it('does not load the unverified page when current user call is successful', () => {
+    const { container } = render(
+      <BrowserRouter>
+        <Router
+          keycloak={keycloak}
+          logout={logout}
+        />
+      </BrowserRouter>
+    );
+    const unverified = findByTestId(container, 'unverified-user');
+    expect(unverified).not.toBeInTheDocument;
+  });
+
+  it('loads the unverified page when the current user call failes', () => {
+    const { container } = render(
+      <BrowserRouter>
+        <Router
+          keycloak={keycloak}
+          logout={logout}
+        />
+      </BrowserRouter>
+    );
+    const unverified = findByTestId(container, 'unverified-user');
+    expect(unverified).toBeInTheDocument;
+  });
+
+  it('renders without crashing', () => {
+    render(
+      <BrowserRouter>
+        <Router
+          keycloak={keycloak}
+          logout={logout}
+        />
+      </BrowserRouter>
+    );
+  });
+
+});

--- a/frontend/src/app/components/Unverified.js
+++ b/frontend/src/app/components/Unverified.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+const Unverified = (props) => (
+  <div 
+    className='m-3' 
+    testid="unverified-user"
+  >
+    <div className='mb-3'>Your account is currently inactive. Please contact your administrator to re-activate your account.</div>
+    <button
+      className="button primary"
+      onClick={() => {
+        props.logout();
+      }}
+      type="button"
+    >
+      <FontAwesomeIcon icon="sign-out-alt" /> <span>Logout</span>
+    </button>
+  </div>
+);
+
+export default Unverified;

--- a/frontend/src/app/router.js
+++ b/frontend/src/app/router.js
@@ -60,6 +60,7 @@ import ROUTES_USERS from './routes/Users';
 import ROUTES_VEHICLES from './routes/Vehicles';
 import ROUTES_COMPLIANCE from './routes/Compliance';
 import ROUTES_SUPPLEMENTARY from './routes/SupplementaryReport';
+import Unverified from './components/Unverified';
 
 class Router extends Component {
   constructor(props) {
@@ -67,7 +68,7 @@ class Router extends Component {
     this.state = {
       loading: true,
       statusCode: null,
-      user: {}
+      user: null,
     };
 
     const { keycloak } = props;
@@ -127,6 +128,12 @@ class Router extends Component {
           }
         }
       });
+    })
+    .catch((error) => {
+      this.setState({
+        loading: false,
+        user: null
+      })
     });
   }
 
@@ -135,6 +142,10 @@ class Router extends Component {
     const { loading, statusCode, user } = this.state;
     if (loading) {
       return <Loading />;
+    }
+
+    if(!user) {
+      return <Unverified logout={this.props.logout} />;
     }
 
     return (

--- a/frontend/src/organizations/components/VehicleSupplierEditForm.js
+++ b/frontend/src/organizations/components/VehicleSupplierEditForm.js
@@ -49,8 +49,8 @@ const VehicleSupplierEditForm = (props) => {
       <p>
         You have selected to make this vehicle supplier Inactive. <br />
         <br />
-        They will no longer have the ability to make any further changes within
-        their account and all their users will have read only access
+        They will no longer have the ability to access their account 
+        and all their users will be made Inactive.
       </p>
       <br />
       <p>Do you want to make this supplier Inactive?</p>


### PR DESCRIPTION
- update serializer on organization now sets all users to inactive when organization is set to inactive
- added unverified user page with logout
- added router testing for unverified user page