### PR TITLE
fix: zeva 461 - credit agreements issues

### DIFF
--- a/frontend/src/app/components/CreditTransactionTabs.js
+++ b/frontend/src/app/components/CreditTransactionTabs.js
@@ -43,9 +43,8 @@ const CreditTransactionTabs = (props) => {
       )}
       {CONFIG.FEATURES.CREDIT_AGREEMENTS.ENABLED &&
         typeof user.hasPermission === 'function' &&
-        ((user.hasPermission('VIEW_INITIATIVE_AGREEMENTS') &&
-          user.isGovernment) ||
-          !user.isGovernment) && (
+        user.hasPermission('VIEW_INITIATIVE_AGREEMENTS') &&
+        user.isGovernment && (
           <li
             className={`nav-item ${
               active === 'credit-agreements' ? 'active' : ''

--- a/frontend/src/app/router.js
+++ b/frontend/src/app/router.js
@@ -534,23 +534,31 @@ class Router extends Component {
                   exact
                   key="route-credit-agreements-list"
                   path={ROUTES_CREDIT_AGREEMENTS.LIST}
-                  render={() => (
-                    <CreditAgreementListContainer
-                      keycloak={keycloak}
-                      user={user}
-                    />
-                  )}
+                  render={() =>
+                    user.isGovernment ? (
+                      <CreditAgreementListContainer
+                        keycloak={keycloak}
+                        user={user}
+                      />
+                    ) : (
+                      <></>
+                    )
+                  }
                 />,
                 <Route
                   exact
                   key="route-credit-agreements-edit"
                   path={ROUTES_CREDIT_AGREEMENTS.EDIT}
-                  render={() => (
-                    <CreditAgreementsEditContainer
-                      keycloak={keycloak}
-                      user={user}
-                    />
-                  )}
+                  render={() =>
+                    user.isGovernment ? (
+                      <CreditAgreementsEditContainer
+                        keycloak={keycloak}
+                        user={user}
+                      />
+                    ) : (
+                      <></>
+                    )
+                  }
                 />,
                 <Route
                   exact
@@ -571,12 +579,16 @@ class Router extends Component {
                   exact
                   key="route-credit-agreements-details"
                   path={ROUTES_CREDIT_AGREEMENTS.DETAILS}
-                  render={() => (
-                    <CreditAgreementsDetailsContainer
-                      keycloak={keycloak}
-                      user={user}
-                    />
-                  )}
+                  render={() =>
+                    user.isGovernment ? (
+                      <CreditAgreementsDetailsContainer
+                        keycloak={keycloak}
+                        user={user}
+                      />
+                    ) : (
+                      <></>
+                    )
+                  }
                 />
               ]}
               <Route

--- a/frontend/src/creditagreements/components/CreditAgreementsListTable.js
+++ b/frontend/src/creditagreements/components/CreditAgreementsListTable.js
@@ -100,9 +100,11 @@ const CreditAgreementsListTable = (props) => {
       accessor: (item) => getCredits(item, 'A'),
       id: 'colaCredits',
       getProps: (state, rowInfo) => ({
-        className: `text-right ${
-          rowInfo.row.colaCredits.slice(0, 2) < 0 ? 'text-danger' : ''
-        }`
+        className: rowInfo
+          ? `text-right ${
+              rowInfo.row.colaCredits.slice(0, 2) < 0 ? 'text-danger' : ''
+            }`
+          : ''
       })
     },
     {
@@ -110,9 +112,11 @@ const CreditAgreementsListTable = (props) => {
       accessor: (item) => getCredits(item, 'B'),
       id: 'colbCredits',
       getProps: (state, rowInfo) => ({
-        className: `text-right ${
-          rowInfo.row.colbCredits.slice(0, 2) < 0 ? 'text-danger' : ''
-        }`
+        className: rowInfo
+          ? `text-right ${
+              rowInfo.row.colbCredits.slice(0, 2) < 0 ? 'text-danger' : ''
+            }`
+          : ''
       })
     },
     {

--- a/frontend/src/credits/components/CreditTransfersListTable.js
+++ b/frontend/src/credits/components/CreditTransfersListTable.js
@@ -65,13 +65,15 @@ const CreditTransfersListTable = (props) => {
       accessor: 'debitFrom.shortName',
       className: 'text-left',
       Header: 'Seller',
-      id: 'seller'
+      id: 'seller',
+      maxWidth: 250
     },
     {
       accessor: 'creditTo.shortName',
       className: 'text-left',
       Header: 'Buyer',
-      id: 'buyer'
+      id: 'buyer',
+      maxWidth: 250
     },
     {
       accessor: (row) =>


### PR DESCRIPTION
fix: adds conditions to getprops in agreement list table, and in router on frontend, and for displaying agreements tab (only idir should see it),
chore: adds maxWidth to shortname of seller
fix: removes extra transaction column, adds condition for displaying