### PR TITLE
Email Notifications Bug Fix - 1265

### DIFF
--- a/backend/api/services/model_year_report.py
+++ b/backend/api/services/model_year_report.py
@@ -24,6 +24,7 @@ from api.models.weight_class import WeightClass
 from api.models.organization import Organization
 from api.models.account_balance import AccountBalance
 from api.models.model_year_report_credit_transaction import ModelYearReportCreditTransaction
+from api.services.send_email import notifications_model_year_report
 
 
 def get_model_year_report_statuses(report, request_user=None):
@@ -363,3 +364,7 @@ def adjust_credits(id, request):
                 organization_id=organization_id,
                 model_year_id=model_year_id
             ).delete()
+
+def check_validation_status_change(current_status, new_status, user):
+        if new_status != current_status and new_status != "DRAFT":
+            notifications_model_year_report(new_status, user)

--- a/backend/api/viewsets/credit_request.py
+++ b/backend/api/viewsets/credit_request.py
@@ -86,7 +86,8 @@ class CreditRequestViewset(
         if submission.validation_status == SalesSubmissionStatuses.VALIDATED:
             award_credits(submission)
 
-        notifications_credit_application(submission)
+        if self.request.method != "PATCH":
+            notifications_credit_application(submission)
 
     @action(detail=False)
     def template(self, request):

--- a/backend/api/viewsets/model_year_report.py
+++ b/backend/api/viewsets/model_year_report.py
@@ -436,7 +436,6 @@ class ModelYearReportViewset(
             )
             item.delete()
 
-        print("validation", validation_status, model_year_report_check)
         check_validation_status_change(model_year_report_check.validation_status, validation_status, user)
 
         if validation_status:

--- a/backend/api/viewsets/model_year_report.py
+++ b/backend/api/viewsets/model_year_report.py
@@ -465,8 +465,10 @@ class ModelYearReportViewset(
 
             if validation_status == "ASSESSED":
                 adjust_credits(model_year_report_id, request)
-
-            notifications_model_year_report(validation_status, request.user)
+                notifications_model_year_report(validation_status, request.user)
+                
+            if self.request.method != "PATCH":
+                notifications_model_year_report(validation_status, request.user)
 
         if confirmations:
             for confirmation in confirmations:

--- a/backend/api/viewsets/vehicle.py
+++ b/backend/api/viewsets/vehicle.py
@@ -20,6 +20,7 @@ from api.serializers.vehicle import ModelYearSerializer, \
 from api.services.minio import minio_put_object
 from auditable.views import AuditableMixin
 from api.models.vehicle import VehicleDefinitionStatuses
+from api.services.send_email import notifications_zev_model
 
 class VehicleViewSet(
     AuditableMixin, viewsets.GenericViewSet, mixins.CreateModelMixin,
@@ -138,6 +139,8 @@ class VehicleViewSet(
             return Response(serializer.errors)
 
         serializer.save()
+
+        notifications_zev_model(request, request.data['validation_status'])
 
         return Response(serializer.data)
 


### PR DESCRIPTION
- Added checks for patch requests to avoid emails being sent out on comments being posted or general saving happens.
- Added logic for emails to be sent out when model year reports are issued for assessment or reassessment.
- Added logic for emails to be sent out when ZEV models are approved.