### PR TITLE
fix: ZEVA 1306 - MY Report status message error

### DIFF
--- a/backend/api/services/model_year_report.py
+++ b/backend/api/services/model_year_report.py
@@ -112,14 +112,17 @@ def get_model_year_report_statuses(report, request_user=None):
 
     if report.validation_status == ModelYearReportStatuses.RECOMMENDED:
         assessment_status = 'RECOMMENDED'
+        supplier_information_status = 'RECOMMENDED'
+        consumer_sales_status = 'RECOMMENDED'
+        compliance_obligation_status = 'RECOMMENDED'
+        summary_status = 'RECOMMENDED'
 
         if not request_user.is_government:
             assessment_status = 'SUBMITTED'
-
-        supplier_information_status = 'SUBMITTED'
-        consumer_sales_status = 'SUBMITTED'
-        compliance_obligation_status = 'SUBMITTED'
-        summary_status = 'SUBMITTED'
+            supplier_information_status = 'SUBMITTED'
+            consumer_sales_status = 'SUBMITTED'
+            compliance_obligation_status = 'SUBMITTED'
+            summary_status = 'SUBMITTED'
 
         user_profile = UserProfile.objects.filter(username=report.update_user)
         if user_profile.exists():
@@ -132,9 +135,16 @@ def get_model_year_report_statuses(report, request_user=None):
 
     if report.validation_status == ModelYearReportStatuses.RETURNED:
         assessment_status = 'RETURNED'
-
+        supplier_information_status = 'RETURNED'
+        consumer_sales_status = 'RETURNED'
+        compliance_obligation_status = 'RETURNED'
+        summary_status = 'RETURNED'
         if not request_user.is_government:
             assessment_status = 'SUBMITTED'
+            supplier_information_status = 'SUBMITTED'
+            consumer_sales_status = 'SUBMITTED'
+            compliance_obligation_status = 'SUBMITTED'
+            summary_status = 'SUBMITTED'
 
         user_profile = UserProfile.objects.filter(username=report.update_user)
         if user_profile.exists():

--- a/backend/api/viewsets/model_year_report_consumer_sales.py
+++ b/backend/api/viewsets/model_year_report_consumer_sales.py
@@ -149,9 +149,8 @@ class ModelYearReportConsumerSalesViewSet(mixins.ListModelMixin,
         history = ModelYearReportHistorySerializer(history_list, many=True)
 
         validation_status = report.validation_status.value
-
         if not request.user.is_government and \
-                report.validation_status == ModelYearReportStatuses.RETURNED:
+                (report.validation_status == ModelYearReportStatuses.RETURNED or report.validation_status == ModelYearReportStatuses.RECOMMENDED):
             validation_status = ModelYearReportStatuses.SUBMITTED.value
 
         return Response({

--- a/frontend/src/compliance/components/ComplianceReportAlert.js
+++ b/frontend/src/compliance/components/ComplianceReportAlert.js
@@ -84,14 +84,11 @@ const ComplianceReportAlert = (props) => {
         classname = 'alert-primary';
         break;
 
-
       case 'ASSESSED':
         title = 'Model Year Report Assessed';
         message = `Model Year Report Assessed ${date} by Government of B.C. — ${type} submitted ${confirmedBy.date} by ${confirmedBy.user}`;
         classname = 'alert-success';
         break;
-      
-
 
       default:
         title = '';
@@ -132,7 +129,6 @@ const ComplianceReportAlert = (props) => {
       message = `${type} confirmed ${confirmedBy.date} by ${confirmedBy.user}`;
       classname = 'alert-primary';
       break;
-
 
     case 'ASSESSED':
       title = 'Model Year Report Assessed';

--- a/frontend/src/compliance/components/ComplianceReportAlert.js
+++ b/frontend/src/compliance/components/ComplianceReportAlert.js
@@ -36,6 +36,16 @@ const ComplianceReportAlert = (props) => {
           user: statusFilter('SUBMITTED').createUser.displayName
         };
       }
+      if (validationStatus === 'RETURNED' || validationStatus === 'RECOMMENDED') {
+        // if the status is returned or recommended, we now want to see the user
+        // who submitted originally, so if we ever change our minds and want to see
+        // the actual alert information (ie the director that returned or the analyst
+        // that recommended),this needs to be updated
+          date = moment(statusFilter('SUBMITTED').createTimestamp).format(
+            'MMM D, YYYY'
+          ),
+          userName = statusFilter('SUBMITTED').createUser.displayName
+      }
     }
   }
 
@@ -67,16 +77,13 @@ const ComplianceReportAlert = (props) => {
         break;
 
       case 'SUBMITTED':
+      case 'RETURNED':
+      case 'RECOMMENDED':
         title = 'Model Year Report Submitted';
         message = `Model Year Report Submitted ${date} by ${userName}`;
         classname = 'alert-primary';
         break;
 
-      case 'RECOMMENDED':
-        title = 'Model Year Report Recommended';
-        message = `Model Year Report Recommended ${date} by ${userName}`;
-        classname = 'alert-primary';
-        break;
 
       case 'ASSESSED':
         title = 'Model Year Report Assessed';
@@ -84,11 +91,7 @@ const ComplianceReportAlert = (props) => {
         classname = 'alert-success';
         break;
       
-      case 'RETURNED':
-        title = 'Model Year Report Returned';
-        message = `Model Year Report Returned ${date} by ${userName}`;
-        classname = 'alert-primary';
-        break;
+
 
       default:
         title = '';
@@ -123,16 +126,13 @@ const ComplianceReportAlert = (props) => {
       break;
 
     case 'SUBMITTED':
+    case 'RETURNED':
+    case 'RECOMMENDED':
       title = 'Model Year Report Submitted';
-      message = `Model Year Report Submitted ${date} by ${userName} — ${type} confirmed ${confirmedBy.date} by ${confirmedBy.user}`;
+      message = `${type} confirmed ${confirmedBy.date} by ${confirmedBy.user}`;
       classname = 'alert-primary';
       break;
 
-    case 'RECOMMENDED':
-        title = 'Recommended';
-        message = `Model Year Report recommended ${date} by ${userName}, pending Director assessment. Signed and submitted ${confirmedBy.date} by ${confirmedBy.user}`;
-        classname = 'alert-primary';
-        break;
 
     case 'ASSESSED':
       title = 'Model Year Report Assessed';
@@ -140,12 +140,6 @@ const ComplianceReportAlert = (props) => {
       classname = 'alert-success';
       break;
     
-    case 'RETURNED':
-        title = 'Model Year Report Returned';
-        message = `Model Year Report Returned ${date} by ${userName}`;
-        classname = 'alert-primary';
-        break;
-
     default:
       title = '';
   }

--- a/frontend/src/compliance/components/ComplianceReportAlert.js
+++ b/frontend/src/compliance/components/ComplianceReportAlert.js
@@ -72,55 +72,28 @@ const ComplianceReportAlert = (props) => {
         classname = 'alert-primary';
         break;
 
+      case 'RECOMMENDED':
+        title = 'Model Year Report Recommended';
+        message = `Model Year Report Recommended ${date} by ${userName}`;
+        classname = 'alert-primary';
+        break;
+
       case 'ASSESSED':
         title = 'Model Year Report Assessed';
         message = `Model Year Report Assessed ${date} by Government of B.C. — ${type} submitted ${confirmedBy.date} by ${confirmedBy.user}`;
         classname = 'alert-success';
         break;
-
-      default:
-        title = '';
-    }
-
-    return (
-      <Alert
-        title={title}
-        icon={icon}
-        classname={classname}
-        message={message}
-      />
-    );
-  }
-  if (type === 'Assessment') {
-    switch (status && status.status) {
-      case 'UNSAVED':
-        title = 'Submitted';
-        message = ` Model year report signed and submitted ${date} by ${userName}. Pending analyst review and Director assessment.`;
-        classname = 'alert-warning';
-        break;
-      case 'SUBMITTED':
-        title = 'Submitted';
-        message = ` Model year report signed and submitted ${date} by ${userName}. Pending analyst review and Director assessment.`;
-        classname = 'alert-warning';
-        break;
-      case 'RECOMMENDED':
-        title = 'Recommended';
-        message = `Model Year Report recommended ${date} by ${userName}, pending Director assessment. Signed and submitted ${confirmedBy.date} by ${confirmedBy.user}`;
-        classname = 'alert-primary';
-        break;
+      
       case 'RETURNED':
-        title = 'Returned';
-        message = `Model Year Report returned ${date} by Director, Pending analyst review and Director assessment. Signed and submitted ${confirmedBy.date} by ${confirmedBy.user}`;
+        title = 'Model Year Report Returned';
+        message = `Model Year Report Returned ${date} by ${userName}`;
         classname = 'alert-primary';
         break;
-      case 'ASSESSED':
-        title = 'Assessed';
-        message = `Model Year Report Assessed ${date} by Government of B.C.`;
-        classname = 'alert-success';
-        break;
+
       default:
         title = '';
     }
+
     return (
       <Alert
         title={title}
@@ -155,11 +128,23 @@ const ComplianceReportAlert = (props) => {
       classname = 'alert-primary';
       break;
 
+    case 'RECOMMENDED':
+        title = 'Recommended';
+        message = `Model Year Report recommended ${date} by ${userName}, pending Director assessment. Signed and submitted ${confirmedBy.date} by ${confirmedBy.user}`;
+        classname = 'alert-primary';
+        break;
+
     case 'ASSESSED':
       title = 'Model Year Report Assessed';
       message = `Model Year Report Assessed ${date} by Government of B.C. — ${type} confirmed ${confirmedBy.date} by ${confirmedBy.user}`;
       classname = 'alert-success';
       break;
+    
+    case 'RETURNED':
+        title = 'Model Year Report Returned';
+        message = `Model Year Report Returned ${date} by ${userName}`;
+        classname = 'alert-primary';
+        break;
 
     default:
       title = '';


### PR DESCRIPTION
fix: adds RETURNED and RECOMMENDED statuses to ComplianceReportAlerts, shares case with submitted
fix: adds recommended to condition for displaying validation_status in consumer sales so it won't show up on network tab
fix: adds some logic on the model_year_report_statuses service for how RECOMMENDED and RETURNED reports are passed to frontend

