### PR TITLE
fix: zeva-1365 - allow Zero value in model year LDV Sales field

### DIFF
--- a/frontend/src/supplementary/components/CreditActivity.js
+++ b/frontend/src/supplementary/components/CreditActivity.js
@@ -750,7 +750,6 @@ const CreditActivity = (props) => {
 CreditActivity.defaultProps = {
   creditReductionSelection: '',
   isEditable: false,
-  newLdvSales: null,
   supplierClass: ''
 };
 
@@ -764,7 +763,6 @@ CreditActivity.propTypes = {
     .isRequired,
   newBalances: PropTypes.shape().isRequired,
   newData: PropTypes.shape().isRequired,
-  newLdvSales: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   obligationDetails: PropTypes.arrayOf(PropTypes.shape()).isRequired,
   ratios: PropTypes.shape().isRequired,
   supplierClass: PropTypes.string

--- a/frontend/src/supplementary/components/CreditActivity.js
+++ b/frontend/src/supplementary/components/CreditActivity.js
@@ -20,13 +20,16 @@ const CreditActivity = (props) => {
     ldvSales,
     newBalances,
     newData,
-    newLdvSales,
     obligationDetails,
     ratios,
     supplierClass,
     isEditable
   } = props;
-
+  let newLdvSales =
+    newData && newData.supplierInfo && newData.supplierInfo.ldvSales;
+  if (newLdvSales === null) {
+    newLdvSales = ldvSales;
+  }
   let reportYear = false;
 
   if (details && details.assessmentData) {

--- a/frontend/src/supplementary/components/CreditActivity.js
+++ b/frontend/src/supplementary/components/CreditActivity.js
@@ -290,7 +290,7 @@ const CreditActivity = (props) => {
                       name="supplierInfo"
                       type="text"
                       onChange={handleInputChange}
-                      defaultValue={newLdvSales || ldvSales}
+                      defaultValue={newLdvSales}
                       readOnly={!isEditable}
                     />
                   </td>
@@ -305,7 +305,7 @@ const CreditActivity = (props) => {
                       totalReduction !== newTotalReduction ? 'highlight' : ''
                     }`}
                   >
-                    {newLdvSales && (
+                    {newLdvSales >= 0 && (
                       <span>{formatNumeric(newTotalReduction, 2)}</span>
                     )}
                   </td>
@@ -329,7 +329,7 @@ const CreditActivity = (props) => {
                             : ''
                         }`}
                       >
-                        {newLdvSales && (
+                        {newLdvSales >= 0 && (
                           <span>{formatNumeric(newClassAReduction, 2)}</span>
                         )}
                       </td>
@@ -349,7 +349,7 @@ const CreditActivity = (props) => {
                             : ''
                         }`}
                       >
-                        {newLdvSales && (
+                        {newLdvSales >= 0 && (
                           <span>{formatNumeric(newLeftoverReduction, 2)}</span>
                         )}
                       </td>
@@ -376,7 +376,7 @@ const CreditActivity = (props) => {
                           : ''
                       }`}
                     >
-                      {newLdvSales && (
+                      {newLdvSales >= 0 && (
                         <span>{formatNumeric(newLeftoverReduction, 2)}</span>
                       )}
                     </td>

--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -347,7 +347,6 @@ const SupplementaryAnalystDetails = (props) => {
             salesRows={salesRows}
             isEditable={isEditable && currentStatus !== 'RECOMMENDED'}
           />
-          {console.log(details)}
           <CreditActivity
             creditReductionSelection={creditReductionSelection}
             details={details}

--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -65,9 +65,11 @@ const SupplementaryAnalystDetails = (props) => {
   const creditReductionSelection =
     details.assessmentData && details.assessmentData.creditReductionSelection;
 
-  const newLdvSales =
+  let newLdvSales =
     newData && newData.supplierInfo && newData.supplierInfo.ldvSales;
-    
+  if (newLdvSales === null) {
+    newLdvSales = ldvSales;
+  }
   let currentStatus = details.actualStatus
     ? details.actualStatus
     : details.status;
@@ -281,7 +283,6 @@ const SupplementaryAnalystDetails = (props) => {
       </ul>
     )
   }
-
   return (
     <div id="supplementary" className="page">
         <ComplianceHistory
@@ -346,6 +347,7 @@ const SupplementaryAnalystDetails = (props) => {
             salesRows={salesRows}
             isEditable={isEditable && currentStatus !== 'RECOMMENDED'}
           />
+          {console.log(details)}
           <CreditActivity
             creditReductionSelection={creditReductionSelection}
             details={details}
@@ -354,7 +356,7 @@ const SupplementaryAnalystDetails = (props) => {
             ldvSales={ldvSales}
             newBalances={newBalances}
             newData={newData}
-            newLdvSales={newLdvSales || ldvSales}
+            newLdvSales={newLdvSales}
             obligationDetails={obligationDetails}
             ratios={ratios}
             supplierClass={supplierClass}

--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -65,11 +65,6 @@ const SupplementaryAnalystDetails = (props) => {
   const creditReductionSelection =
     details.assessmentData && details.assessmentData.creditReductionSelection;
 
-  let newLdvSales =
-    newData && newData.supplierInfo && newData.supplierInfo.ldvSales;
-  if (newLdvSales === null) {
-    newLdvSales = ldvSales;
-  }
   let currentStatus = details.actualStatus
     ? details.actualStatus
     : details.status;
@@ -355,7 +350,6 @@ const SupplementaryAnalystDetails = (props) => {
             ldvSales={ldvSales}
             newBalances={newBalances}
             newData={newData}
-            newLdvSales={newLdvSales}
             obligationDetails={obligationDetails}
             ratios={ratios}
             supplierClass={supplierClass}

--- a/frontend/src/supplementary/components/SupplementaryCreate.js
+++ b/frontend/src/supplementary/components/SupplementaryCreate.js
@@ -59,11 +59,6 @@ const SupplementaryCreate = (props) => {
   const creditReductionSelection =
     details.assessmentData && details.assessmentData.creditReductionSelection;
 
-  let newLdvSales =
-    newData && newData.supplierInfo && newData.supplierInfo.ldvSales;
-  if (newLdvSales === null) {
-    newLdvSales = ldvSales;
-  }
   const isGovernment = user.isGovernment
 
   if (query && query.reassessment === 'Y') {
@@ -179,7 +174,6 @@ const SupplementaryCreate = (props) => {
             ldvSales={ldvSales}
             newBalances={newBalances}
             newData={newData}
-            newLdvSales={newLdvSales}
             obligationDetails={obligationDetails}
             ratios={ratios}
             supplierClass={supplierClass}

--- a/frontend/src/supplementary/components/SupplementaryCreate.js
+++ b/frontend/src/supplementary/components/SupplementaryCreate.js
@@ -59,9 +59,11 @@ const SupplementaryCreate = (props) => {
   const creditReductionSelection =
     details.assessmentData && details.assessmentData.creditReductionSelection;
 
-  const newLdvSales =
+  let newLdvSales =
     newData && newData.supplierInfo && newData.supplierInfo.ldvSales;
-
+  if (newLdvSales === null) {
+    newLdvSales = ldvSales;
+  }
   const isGovernment = user.isGovernment
 
   if (query && query.reassessment === 'Y') {
@@ -177,7 +179,7 @@ const SupplementaryCreate = (props) => {
             ldvSales={ldvSales}
             newBalances={newBalances}
             newData={newData}
-            newLdvSales={newLdvSales || ldvSales}
+            newLdvSales={newLdvSales}
             obligationDetails={obligationDetails}
             ratios={ratios}
             supplierClass={supplierClass}

--- a/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
@@ -67,11 +67,6 @@ const SupplementaryDirectorDetails = (props) => {
     details.assessmentData && details.assessmentData.supplierClass[0];
   const creditReductionSelection =
     details.assessmentData && details.assessmentData.creditReductionSelection;
-  let newLdvSales =
-    newData && newData.supplierInfo && newData.supplierInfo.ldvSales;
-  if (newLdvSales === null) {
-    newLdvSales = ldvSales;
-  }
   let currentStatus = details.actualStatus
     ? details.actualStatus
     : details.status;
@@ -388,7 +383,6 @@ const SupplementaryDirectorDetails = (props) => {
                 ldvSales={ldvSales}
                 newBalances={newBalances}
                 newData={newData}
-                newLdvSales={newLdvSales}
                 obligationDetails={obligationDetails}
                 ratios={ratios}
                 supplierClass={supplierClass}

--- a/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
@@ -67,8 +67,11 @@ const SupplementaryDirectorDetails = (props) => {
     details.assessmentData && details.assessmentData.supplierClass[0];
   const creditReductionSelection =
     details.assessmentData && details.assessmentData.creditReductionSelection;
-  const newLdvSales =
+  let newLdvSales =
     newData && newData.supplierInfo && newData.supplierInfo.ldvSales;
+  if (newLdvSales === null) {
+    newLdvSales = ldvSales;
+  }
   let currentStatus = details.actualStatus
     ? details.actualStatus
     : details.status;
@@ -385,7 +388,7 @@ const SupplementaryDirectorDetails = (props) => {
                 ldvSales={ldvSales}
                 newBalances={newBalances}
                 newData={newData}
-                newLdvSales={newLdvSales || ldvSales}
+                newLdvSales={newLdvSales}
                 obligationDetails={obligationDetails}
                 ratios={ratios}
                 supplierClass={supplierClass}

--- a/frontend/src/supplementary/components/SupplementarySupplierDetails.js
+++ b/frontend/src/supplementary/components/SupplementarySupplierDetails.js
@@ -72,11 +72,6 @@ const SupplementarySupplierDetails = (props) => {
   const creditReductionSelection =
     details.assessmentData && details.assessmentData.creditReductionSelection;
 
-  let newLdvSales =
-    newData && newData.supplierInfo && newData.supplierInfo.ldvSales;
-  if (newLdvSales === null) {
-    newLdvSales = ldvSales;
-  }
   let currentStatus = details.actualStatus
     ? details.actualStatus
     : details.status;
@@ -297,7 +292,6 @@ const SupplementarySupplierDetails = (props) => {
             ldvSales={ldvSales}
             newBalances={newBalances}
             newData={newData}
-            newLdvSales={newLdvSales}
             obligationDetails={obligationDetails}
             ratios={ratios}
             supplierClass={supplierClass}

--- a/frontend/src/supplementary/components/SupplementarySupplierDetails.js
+++ b/frontend/src/supplementary/components/SupplementarySupplierDetails.js
@@ -72,9 +72,11 @@ const SupplementarySupplierDetails = (props) => {
   const creditReductionSelection =
     details.assessmentData && details.assessmentData.creditReductionSelection;
 
-  const newLdvSales =
+  let newLdvSales =
     newData && newData.supplierInfo && newData.supplierInfo.ldvSales;
-
+  if (newLdvSales === null) {
+    newLdvSales = ldvSales;
+  }
   let currentStatus = details.actualStatus
     ? details.actualStatus
     : details.status;
@@ -295,7 +297,7 @@ const SupplementarySupplierDetails = (props) => {
             ldvSales={ldvSales}
             newBalances={newBalances}
             newData={newData}
-            newLdvSales={newLdvSales || ldvSales}
+            newLdvSales={newLdvSales}
             obligationDetails={obligationDetails}
             ratios={ratios}
             supplierClass={supplierClass}


### PR DESCRIPTION
newLdvSales values that were 0 were given a 'false' value and not being passed in ternary for CreditActivity props.

Rather than update the ldvSales values on every component, this updates it on just CreditActivity and removes newLdvSales from the other components