### PR TITLE
partial fix: Zeva 1432 - Supplementary Bugs

### DIFF
--- a/backend/api/serializers/model_year_report.py
+++ b/backend/api/serializers/model_year_report.py
@@ -245,6 +245,11 @@ class ModelYearReportListSerializer(ModelSerializer, EnumSupportSerializerMixin)
             .filter(~Q(status=ModelYearReportStatuses.DELETED))
             .order_by("-create_timestamp")
         )
+        SubQuery = UserProfile.objects.filter(organization__is_government=True).values_list('username', flat=True)
+        if not request.user.is_government:
+            supplementals = supplementals.exclude(Q(status__in=[
+                ModelYearReportStatuses.DRAFT
+            ] ) & Q(create_user__in=SubQuery) )
         supplementals_length = len(supplementals)
         if supplementals_length > 0:
             latest_supplemental = supplementals[0]

--- a/backend/api/serializers/model_year_report.py
+++ b/backend/api/serializers/model_year_report.py
@@ -248,7 +248,7 @@ class ModelYearReportListSerializer(ModelSerializer, EnumSupportSerializerMixin)
         SubQuery = UserProfile.objects.filter(organization__is_government=True).values_list('username', flat=True)
         if not request.user.is_government:
             supplementals = supplementals.exclude(Q(status__in=[
-                ModelYearReportStatuses.DRAFT
+                ModelYearReportStatuses.DRAFT, ModelYearReportStatuses.RECOMMENDED
             ] ) & Q(create_user__in=SubQuery) )
         supplementals_length = len(supplementals)
         if supplementals_length > 0:

--- a/frontend/src/supplementary/components/CreditActivity.js
+++ b/frontend/src/supplementary/components/CreditActivity.js
@@ -27,7 +27,7 @@ const CreditActivity = (props) => {
   } = props
   let newLdvSales =
     newData && newData.supplierInfo && newData.supplierInfo.ldvSales
-  if (newLdvSales === null) {
+  if (newLdvSales === null || !newLdvSales) {
     newLdvSales = ldvSales
   }
   let reportYear = false

--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -39,6 +39,7 @@ const SupplementaryAnalystDetails = (props) => {
     ldvSales,
     loading,
     newBalances,
+    newData,
     obligationDetails,
     radioDescriptions,
     ratios,
@@ -49,7 +50,6 @@ const SupplementaryAnalystDetails = (props) => {
     query
   } = props
 
-  const { newData } = props
   const { reassessment } = details
 
   if (loading) {

--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -357,7 +357,7 @@ const SupplementaryAnalystDetails = (props) => {
           : (
             <>
             <SupplierInformation
-              isEditable={isEditable && currentStatus !== 'RECOMMENDED' && currentStatus !== 'DRAFT'}
+              isEditable={isEditable && currentStatus !== 'RECOMMENDED'}
               user={user}
               details={details}
               handleInputChange={handleInputChange}
@@ -369,7 +369,7 @@ const SupplementaryAnalystDetails = (props) => {
               details={details}
               handleInputChange={handleInputChange}
               salesRows={salesRows}
-              isEditable={isEditable && currentStatus !== 'RECOMMENDED' && currentStatus !== 'DRAFT'}
+              isEditable={isEditable && currentStatus !== 'RECOMMENDED'}
             />
             <CreditActivity
               creditReductionSelection={creditReductionSelection}
@@ -382,7 +382,7 @@ const SupplementaryAnalystDetails = (props) => {
               obligationDetails={obligationDetails}
               ratios={ratios}
               supplierClass={supplierClass}
-              isEditable={isEditable && currentStatus !== 'RECOMMENDED' && currentStatus !== 'DRAFT'}
+              isEditable={isEditable && currentStatus !== 'RECOMMENDED'}
             />
           </>
             )}
@@ -479,7 +479,7 @@ const SupplementaryAnalystDetails = (props) => {
       )}
       {isEditable && (
         <>
-          {['RECOMMENDED', 'DRAFT'].indexOf(currentStatus) < 0 && (
+          {['RECOMMENDED'].indexOf(currentStatus) < 0 && (
             <h3 className="mt-4 mb-1">
               Analyst Recommended Director Assessment
             </h3>
@@ -488,7 +488,7 @@ const SupplementaryAnalystDetails = (props) => {
             <div className="col-12">
               <div className="grey-border-area  p-3 mt-2">
                 <div>
-                  {['RECOMMENDED', 'DRAFT'].indexOf(currentStatus) < 0 && (
+                  {['RECOMMENDED'].indexOf(currentStatus) < 0 && (
                     <>
                       {radioDescriptions &&
                         radioDescriptions.map(
@@ -604,7 +604,7 @@ const SupplementaryAnalystDetails = (props) => {
               )}
               {CONFIG.FEATURES.SUPPLEMENTAL_REPORT.ENABLED &&
                 isEditable &&
-                ['DRAFT'].indexOf(details.status) < 0 &&
+                ['DRAFT'].indexOf(details.status) >= 0 &&
                 (
                   <Button
                     buttonTooltip={recommendTooltip}

--- a/frontend/src/supplementary/components/SupplierInformation.js
+++ b/frontend/src/supplementary/components/SupplierInformation.js
@@ -103,6 +103,7 @@ const SupplierInformation = (props) => {
         <div className="d-inline-block align-top mt-4 col-sm-5 p-0">
           <input
             className={`form-control ${
+              supplierInfo &&
               supplierInfo.legalName &&
               supplierInfo.legalName !== assessmentData.legalName
                 ? 'highlight'
@@ -112,6 +113,7 @@ const SupplierInformation = (props) => {
             name="supplierInfo"
             onChange={handleInputChange}
             defaultValue={
+              supplierInfo &&
               supplierInfo.legalName
                 ? supplierInfo.legalName
                 : assessmentData.legalName
@@ -152,10 +154,11 @@ const SupplierInformation = (props) => {
           className={`form-control d-inline-block align-top mt-4 col-sm-5 ${checkAddressChanges(
             assessmentData,
             'Service',
-            supplierInfo.serviceAddress,
+            supplierInfo && supplierInfo.serviceAddress,
             assessmentData.reconciledServiceAddress
           )}`}
           defaultValue={
+            supplierInfo &&
             supplierInfo.serviceAddress
               ? supplierInfo.serviceAddress
               : assessmentData && assessmentData.reconciledServiceAddress
@@ -202,11 +205,11 @@ const SupplierInformation = (props) => {
           className={`form-control d-inline-block align-top mt-4 col-sm-5 ${checkAddressChanges(
             assessmentData,
             'Records',
-            supplierInfo.recordsAddress,
+            supplierInfo && supplierInfo.recordsAddress,
             assessmentData.reconciledRecordsAddress
           )}`}
           defaultValue={
-            supplierInfo.recordsAddress
+            supplierInfo && supplierInfo.recordsAddress
               ? supplierInfo.recordsAddress
               : assessmentData && assessmentData.reconciledRecordsAddress
                 ? assessmentData.reconciledRecordsAddress
@@ -238,10 +241,10 @@ const SupplierInformation = (props) => {
         <textarea
           className={`form-control d-inline-block align-top mt-4 col-sm-5 ${checkMakesChanges(
             assessmentData,
-            supplierInfo.ldvMakes
+            supplierInfo && supplierInfo.ldvMakes
           )}`}
           defaultValue={
-            supplierInfo.ldvMakes
+            supplierInfo && supplierInfo.ldvMakes
               ? supplierInfo.ldvMakes
               : assessmentData.makes.join('\n')
           }
@@ -263,13 +266,13 @@ const SupplierInformation = (props) => {
         </div>
         <input
           className={`form-control d-inline-block align-top mt-4 col-sm-5 ${
-            supplierInfo.supplierClass &&
+            supplierInfo && supplierInfo.supplierClass &&
             supplierInfo.supplierClass !== assessmentData.supplierClass
               ? 'highlight'
               : ''
           }`}
           defaultValue={
-            supplierInfo.supplierClass
+            supplierInfo && supplierInfo.supplierClass
               ? supplierInfo.supplierClass
               : assessmentData.supplierClass
           }

--- a/frontend/src/supplementary/components/__tests__/SupplementaryAnalystDetails.test.js
+++ b/frontend/src/supplementary/components/__tests__/SupplementaryAnalystDetails.test.js
@@ -1,0 +1,121 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import SupplementaryAnalystDetails from '../SupplementaryAnalystDetails'
+import '@testing-library/jest-dom/extend-expect'
+import { BrowserRouter as Router } from 'react-router-dom'
+const testFunction = () => {}
+const commentArray = {
+  bdeidComment: [],
+  idirComment: [{
+    id: 1,
+    comment: 'test comment',
+    toDirector: false,
+    createTimestamp: '2023-02-22T15:11:44.183236-08:00',
+    createUser: {
+      displayName: 'Emily Gov Analyst',
+      email: 'email@gov.bc.ca',
+      firstName: 'Emily',
+      id: 2,
+      isActive: true,
+      isMapped: true,
+      lastName: 'Test',
+      phone: null
+    }
+  }]
+}
+const details = {
+  assessmentData: {
+    makes: ['make1', 'make2'],
+    modelYear: '2021',
+    reassessment: true,
+    actualStatus: 'DRAFT',
+    legalName: 'test company',
+    supplierClass: 'L',
+    zevSales: [{
+      id: 15,
+      pendingSales: 0,
+      make: 'make1',
+      modelName: 'model1',
+      range: '420.00',
+      salesIssued: 35,
+      vehicleZevType: 'BEV',
+      zevClass: 'A'
+    }],
+    reportAddress: [{
+      representativeName: 'test name',
+      addressLine1: 'test road',
+      addressType: { addressType: 'Service' },
+      city: 'Victoria',
+      country: 'Canada',
+      county: null,
+      id: 123,
+      postalCode: 'V8Z 4K8',
+      state: 'BC'
+    }]
+  }
+}
+const newData = {}
+const radioDescriptions = [{
+  description: '{user.organization.name} has complied with section 10 (2) of the Zero-Emission Vehicles Act for the {modelYear} model year.',
+  displayOrder: 0,
+  id: 1
+}, {
+  description: '{user.organization.name} has not complied with section 10 (2).',
+  displayOrder: 1,
+  id: 2
+}, {
+  description: '{user.organization.name} has not complied.',
+  displayOrder: 2,
+  id: 3
+}]
+const salesRows = [
+  { newData: {}, oldData: { creditAValue: '2000.00', creditBValue: '100.00', modelYear: '2021', category: 'ProvisionalBalanceAfterCreditReduction' } },
+  { newData: {}, oldData: { creditAValue: '2700.00', creditBValue: '100.00', modelYear: '2021', category: 'creditsIssuedSales' } },
+  { newData: {}, oldData: { creditAValue: '10.00', creditBValue: '10.00', modelYear: '2021', category: 'creditBalanceStart' } }
+]
+describe('SupplementaryAnalystDetails', () => {
+  it('renders without crashing', () => {
+    render(
+      <Router>
+        <SupplementaryAnalystDetails
+          addSalesRow={testFunction}
+          commentArray={commentArray}
+          deleteFiles={[{}]}
+          details={details}
+          handleAddIdirComment={testFunction}
+          handleCommentChangeBceid={testFunction}
+          handleCommentChangeIdir={testFunction}
+          handleDeleteIdirComment={testFunction}
+          handleEditIdirComment={testFunction}
+          handleInputChange={testFunction}
+          handleSubmit={testFunction}
+          handleSupplementalChange={testFunction}
+          id={1}
+          loading={false}
+          ldvSales={1000}
+          newData={newData}
+          newBalances={{}}
+          ratios={{
+            complianceRatio: 12.00,
+            modelYear: '2021',
+            id: 1,
+            zevClassA: 8.00
+          }}
+          radioDescriptions={radioDescriptions}
+          salesRows={salesRows}
+          setSupplementaryAssessmentData={testFunction}
+          supplementaryAssessmentData={
+              {
+                supplementaryAssessment: {
+                  penalty: 0,
+                  decision: { description: '{user.organization.name} has not complied.', id: 3 },
+                  inCompliance: false
+                }
+              }
+            }
+          user={{ isGovernment: true }}
+        />
+      </Router>
+    )
+  })
+})


### PR DESCRIPTION
fixes first two items on bug list plus includes a test that can be added to as I go 

when a reassessment is in draft on the idir side, and bceid opens the model year report, currently it opens a new supplementary. It should open the model year report.
as a bceid user
when i open a model year report that was assessed
it should open the assessed report (even if government is in the process of making a reassessment)


 if a reassessment is in draft the input boxes should be enabled (currently disabled)