### PR TITLE
fix: zeva 1432 - part 3

### DIFF
--- a/backend/api/serializers/model_year_report.py
+++ b/backend/api/serializers/model_year_report.py
@@ -409,18 +409,20 @@ class ModelYearReportListSerializer(ModelSerializer, EnumSupportSerializerMixin)
 
         def get_supplemental_id(obj):
             if latest_supplemental:
-                if not request.user.is_government:
-                    user = UserProfile.objects.filter(
+                create_user = UserProfile.objects.filter(
                         username=latest_supplemental.create_user
                     ).first()
-
+                if request.user.is_government:
+                    if  latest_supplemental.status.value == 'DRAFT' and not create_user.is_government:
+                        return None
+                if not request.user.is_government:
                     if (
-                        user
-                        and not user.is_government
+                        create_user
+                        and not create_user.is_government
                         and latest_supplemental.status.value == "ASSESSED"
                     ) or (
-                        user
-                        and user.is_government
+                        create_user
+                        and create_user.is_government
                         and latest_supplemental.status.value != "ASSESSED"
                     ):
                         for supplemental in supplementals:

--- a/backend/api/viewsets/model_year_report.py
+++ b/backend/api/viewsets/model_year_report.py
@@ -694,16 +694,18 @@ class ModelYearReportViewset(
             if not data:
                 return HttpResponse(status=404, content=None)
 
+            create_user = UserProfile.objects.get(username=data.create_user)
             if data.status == ModelYearReportStatuses.DELETED:
                 return HttpResponse(status=404, content=None)
 
-            if not request.user.is_government and data.status not in [
+            if (not request.user.is_government and data.status not in [
                 ModelYearReportStatuses.DRAFT,
                 ModelYearReportStatuses.SUBMITTED,
                 ModelYearReportStatuses.ASSESSED,
                 ModelYearReportStatuses.REASSESSED,
                 ModelYearReportStatuses.RETURNED,
-            ]:
+            ]) or (request.user.is_government and data.status == ModelYearReportStatuses.DRAFT
+                   and not create_user.is_government):
                 return HttpResponse(status=404, content=None)
         else:
             data = report.get_latest_supplemental(request)

--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -153,10 +153,6 @@ const SupplementaryAnalystDetails = (props) => {
     )
   }
 
-  const handleGovSubmitDraft = (status) => {
-    handleSubmit(status, false)
-  }
-
   const modal = (
     <Modal
       cancelLabel="No"
@@ -556,7 +552,7 @@ const SupplementaryAnalystDetails = (props) => {
                 )}
               />
               {CONFIG.FEATURES.SUPPLEMENTAL_REPORT.ENABLED &&
-                isEditable && (
+                isEditable && isReassessment && (
                   <Button
                     buttonType="delete"
                     action={() => setShowModalDelete(true)}
@@ -591,13 +587,13 @@ const SupplementaryAnalystDetails = (props) => {
                   <Button
                     buttonType="save"
                     action={() => {
-                      handleGovSubmitDraft(currentStatus)
+                      handleSubmit(currentStatus, false)
                     }}
                   />
               )}
               {CONFIG.FEATURES.SUPPLEMENTAL_REPORT.ENABLED &&
                 isEditable &&
-                ['DRAFT'].indexOf(details.status) >= 0 &&
+                ['DRAFT', 'SUBMITTED'].indexOf(details.status) >= 0 &&
                 (
                   <Button
                     buttonTooltip={recommendTooltip}

--- a/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
@@ -84,15 +84,6 @@ const SupplementaryDirectorDetails = (props) => {
   const tabNames = ['supplemental', 'recommendation', 'reassessment']
   const selectedTab = query?.tab ? query.tab : isAssessed || isRecommended ? tabNames[2] : tabNames[1]
 
-  let isEditable = ['DRAFT'].indexOf(details.status) >= 0
-
-  if (selectedTab === tabNames[0] && currentStatus === 'SUBMITTED') {
-    isEditable = false
-  }
-  if (selectedTab === tabNames[1] && currentStatus === 'SUBMITTED') {
-    isEditable = true
-  }
-
   const formattedPenalty = details.assessment
     ? formatNumeric(details.assessment.assessmentPenalty, 0)
     : 0
@@ -288,8 +279,7 @@ const SupplementaryDirectorDetails = (props) => {
         />
 
       {renderTabs()}
-
-      {isEditable && (
+      {selectedTab === tabNames[2] && ['RECOMMENDED'].indexOf(currentStatus) >= 0 && (
         <div className="supplementary-form my-3">
           {commentArray &&
             commentArray.idirComment &&
@@ -339,7 +329,7 @@ const SupplementaryDirectorDetails = (props) => {
             : (
             <>
               <SupplierInformation
-                isEditable={isEditable}
+                isEditable={false}
                 user={user}
                 details={details}
                 handleInputChange={handleInputChange}
@@ -351,7 +341,7 @@ const SupplementaryDirectorDetails = (props) => {
                 details={details}
                 handleInputChange={handleInputChange}
                 salesRows={salesRows}
-                isEditable={isEditable}
+                isEditable={false}
               />
               <CreditActivity
                 creditReductionSelection={creditReductionSelection}
@@ -364,7 +354,7 @@ const SupplementaryDirectorDetails = (props) => {
                 obligationDetails={obligationDetails}
                 ratios={ratios}
                 supplierClass={supplierClass}
-                isEditable={isEditable}
+                isEditable={false}
               />
             </>
               )}
@@ -459,7 +449,7 @@ const SupplementaryDirectorDetails = (props) => {
               </div>
             </>
         }
-      {isEditable && (
+      {selectedTab === tabNames[1] && (
         <>
           {['RECOMMENDED', 'RETURNED'].indexOf(currentStatus) < 0 && (
             <h3 className="mt-4 mb-1">

--- a/frontend/src/supplementary/components/SupplementarySupplierDetails.js
+++ b/frontend/src/supplementary/components/SupplementarySupplierDetails.js
@@ -398,7 +398,7 @@ const SupplementarySupplierDetails = (props) => {
                   id
                 )}
               />
-              {/* {CONFIG.FEATURES.SUPPLEMENTAL_REPORT.ENABLED &&
+              {CONFIG.FEATURES.SUPPLEMENTAL_REPORT.ENABLED &&
                 isEditable && (
                   <Button
                     buttonType="delete"
@@ -413,7 +413,7 @@ const SupplementarySupplierDetails = (props) => {
                         : 'Delete'
                     }
                   />
-                )} */}
+              )}
             </span>
             <span className="right-content">
               {CONFIG.FEATURES.SUPPLEMENTAL_REPORT.ENABLED &&

--- a/frontend/src/supplementary/components/__tests__/SupplementaryAnalystDetails.test.js
+++ b/frontend/src/supplementary/components/__tests__/SupplementaryAnalystDetails.test.js
@@ -119,3 +119,25 @@ describe('SupplementaryAnalystDetails', () => {
     )
   })
 })
+// TESTS TO WRITE
+
+// as an analyst
+// if i view a supplemental report in submitted status
+// i should be able to edit fields, add comments to supplier or director,
+// click a radio button for the assessment, and save/recommend to director or return to supplier
+
+// as an analyst
+// if i view a supplemental report in recommended status
+// I should be able to view a read only version of all 3 tabs
+
+// as an analyst
+// if i view a supplemental report in any status
+// I should be able to view all 3 tabs
+
+// as an analyst
+// if i view a reassessment report in any status
+// I should be able to view the second two tabs
+
+// as an analyst
+// if i view a supplemental report in submitted status
+// I should be able to view a editable version of all 3 tabs


### PR DESCRIPTION
 disable all inputs for director if not recommended, the only thing director should update is the message to supplier

 as a bceid user, i should be able to delete a draft reassessment

 as an idir user, if i open a model year report that has a supplementary draft saved by bceid, it should not display that draft information to me

comment input from director to analyst appears only for recommended status