### PR TITLE
fix: ZEVA 1490 - reassessment comment array/input for director and analyst

### DIFF
--- a/frontend/src/app/components/EditableCommentList.js
+++ b/frontend/src/app/components/EditableCommentList.js
@@ -2,15 +2,16 @@ import React, { useState } from 'react'
 import EditComment from './EditComment'
 import moment from 'moment-timezone'
 import parse from 'html-react-parser'
+import PropTypes from 'prop-types'
 
 const EditableCommentList = ({
   comments,
   user,
   handleCommentEdit,
-  handleCommentDelete
+  handleCommentDelete,
+  enableEditing
 }) => {
   const [commentIdsBeingEdited, setCommentIdsBeingEdited] = useState([])
-
   const handleEditClick = (commentId) => {
     setCommentIdsBeingEdited((prev) => {
       return [...prev, commentId]
@@ -56,7 +57,7 @@ const EditableCommentList = ({
       commentElements.push(
         <div key={commentId}>
           <b>{'Comments - '}</b>
-          {userEditable && (
+          {userEditable && enableEditing && (
             <button
               className="inline-edit"
               onClick={() => {
@@ -80,5 +81,12 @@ const EditableCommentList = ({
     </div>
   )
 }
+EditableCommentList.defaultProps = {
+  enableEditing: true
 
+}
+
+EditableCommentList.propTypes = {
+  enableEditing: PropTypes.bool
+}
 export default EditableCommentList

--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -300,19 +300,24 @@ const SupplementaryAnalystDetails = (props) => {
 
       {renderTabs()}
 
-      {isEditable && (
-        <div className="supplementary-form my-3">
+      {selectedTab === tabNames[1] && (
+        // analyst can see comments on the RECOMMENDATION tab in any status
+        // and can leave/edit comments if its NOT Assessed or Recommended
+        <>
           {commentArray &&
             commentArray.idirComment &&
             commentArray.idirComment.length > 0 && (
+          <div className="supplementary-form my-3">
               <EditableCommentList
+                enableEditing={!['ASSESSED', 'RECOMMENDED'].includes(currentStatus)}
                 comments={commentArray.idirComment}
                 user={user}
                 handleCommentEdit={handleEditIdirComment}
                 handleCommentDelete={handleDeleteIdirComment}
               />
+            </div>
           )}
-
+          {isEditable && (
           <div id="comment-input">
             <CommentInput
               handleCommentChange={handleCommentChangeIdir}
@@ -322,7 +327,8 @@ const SupplementaryAnalystDetails = (props) => {
               tooltip="Please save the report first, before adding comments"
             />
           </div>
-        </div>
+          )}
+      </>
       )}
       <div className="supplementary-form mt-2">
         <Button

--- a/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
@@ -277,21 +277,25 @@ const SupplementaryDirectorDetails = (props) => {
           user={user}
           tabName={selectedTab}
         />
-
       {renderTabs()}
-      {selectedTab === tabNames[2] && ['RECOMMENDED'].indexOf(currentStatus) >= 0 && (
-        <div className="supplementary-form my-3">
+      {selectedTab === tabNames[2] && (
+        // director can see comments on the REASSESSMENT tab in any status
+        // but can only leave or edit comments if its in Recommended Status,
+        <>
           {commentArray &&
             commentArray.idirComment &&
             commentArray.idirComment.length > 0 && (
+              <div className="supplementary-form my-3">
               <EditableCommentList
+                enableEditing={currentStatus === 'RECOMMENDED'}
                 comments={commentArray.idirComment}
                 user={user}
                 handleCommentEdit={handleEditIdirComment}
                 handleCommentDelete={handleDeleteIdirComment}
               />
+              </div>
           )}
-
+          {currentStatus === 'RECOMMENDED' && (
           <div id="comment-input">
             <CommentInput
               handleCommentChange={handleCommentChangeIdir}
@@ -301,7 +305,9 @@ const SupplementaryDirectorDetails = (props) => {
               tooltip="Please save the report first, before adding comments"
             />
           </div>
-        </div>
+          )}
+        </>
+
       )}
       <div className="supplementary-form mt-2">
         <Button


### PR DESCRIPTION
-adds enableEditable boolean to comment list
- makes comments visible for all report statuses but not editable if user is director and status is anything but recommended, or not editable if  user is analyst and status is recommended or assessed