### PR TITLE
fix: Zeva 1490 history component bugs and changes

### DIFF
--- a/frontend/src/compliance/components/ComplianceHistory.js
+++ b/frontend/src/compliance/components/ComplianceHistory.js
@@ -22,48 +22,73 @@ const ComplianceHistory = (props) => {
     supplementaryId = detailsId
   }
 
-  const [supplementalReportHistory, setSupplementalReportHistory] = useState(
-    []
-  )
+  const [supplementalReportHistory, setSupplementalReportHistory] = useState([])
+  const [startedAsSupplemental, setStartedAsSupplemental] = useState(false)
 
   useEffect(() => {
     axios
       .get(ROUTES_COMPLIANCE.SUPPLEMENTAL_HISTORY.replace(/:id/g, id))
       .then((response) => {
         setSupplementalReportHistory(response.data)
+        response.data.forEach((report) => {
+          if (report.isSupplementary === true) {
+            report.history.forEach((row) => {
+              if (row.isReassessment === false) {
+                setStartedAsSupplemental(true)
+              }
+            })
+          }
+        })
       })
   }, [])
 
   const getHistory = (itemHistory) => {
     const tempHistory = []
-
     if (itemHistory) {
       itemHistory.forEach((obj) => {
-        if (['SUBMITTED', 'DRAFT'].indexOf(obj.status) >= 0) {
+        if (['SUBMITTED'].indexOf(obj.status) >= 0) {
           const found = tempHistory.findIndex(
-            (each) => ['SUBMITTED', 'DRAFT'].indexOf(each.status) >= 0
+            (each) => ['SUBMITTED'].indexOf(each.status) >= 0
           )
-
           if (found < 0) {
             tempHistory.push(obj)
           }
         }
-
+        if (['DRAFT'].indexOf(obj.status) >= 0) {
+          const found = tempHistory.findIndex(
+            (each) => ['DRAFT'].indexOf(each.status) >= 0
+          )
+          if (found < 0 && ['DRAFT', 'SUBMITTED'].includes(status)) {
+            tempHistory.push(obj)
+          }
+        }
         if (
           ['RECOMMENDED', 'ASSESSED', 'REASSESSED'].indexOf(obj.status) >= 0
         ) {
           const found = tempHistory.findIndex(
             (each) => obj.status === each.status
           )
-
           if (found < 0) {
             tempHistory.push(obj)
           }
         }
       })
     }
-
     return tempHistory
+  }
+  const getTitle = (item) => {
+    const type = item.isSupplementary ? startedAsSupplemental ? 'Supplementary Report' : 'Reassessment' : 'Model Year Report'
+    let status = item.status
+    if (item.isSupplementary) {
+      if (item.status === 'RECOMMENDED') {
+        status = 'REASSESSMENT RECOMMENDED'
+      } else if (item.status === 'ASSESSED') {
+        status = ' REASSESSED'
+      }
+    } else if (item.status === 'RECOMMENDED') {
+      status = 'ASSESSMENT RECOMMENDED'
+    }
+    return `${type} - ${status}`
   }
 
   const getStatus = (item, each) => {
@@ -101,7 +126,6 @@ const ComplianceHistory = (props) => {
       } else {
         reportType = 'Supplementary report '
       }
-
       if (status === 'assessed') {
         status = 'reassessed'
         reportType = 'Supplementary report '
@@ -198,11 +222,7 @@ const ComplianceHistory = (props) => {
                         }
                       }}
                     >
-                      Model Year {item.isSupplementary ? 'Supplementary' : ''}{' '}
-                      Report -{' '}
-                      {item.status === 'RECOMMENDED'
-                        ? 'ASSESSMENT RECOMMENDED'
-                        : item.status}
+                      {getTitle(item)}
                     </button>
                   </h2>
                 </div>
@@ -219,6 +239,7 @@ const ComplianceHistory = (props) => {
                             id={`each-${eachIndex}`}
                             key={`each-${eachIndex}`}
                           >
+
                             {getStatus(item, each)}
                           </li>
                         ))}

--- a/frontend/src/compliance/components/ComplianceHistory.js
+++ b/frontend/src/compliance/components/ComplianceHistory.js
@@ -13,9 +13,8 @@ require('bootstrap/js/dist/collapse.js')
 const ComplianceHistory = (props) => {
   const {
     id, activePage, supplementaryId: detailsId,
-    reportYear, isReassessment, tabName
+    reportYear, isReassessment, tabName, user
   } = props
-
   let { supplementaryId } = useParams()
 
   if (!supplementaryId && detailsId) {
@@ -115,7 +114,9 @@ const ComplianceHistory = (props) => {
 
     if (status === 'assessed') {
       status = ' assessed '
-      byUser = ' by Government of B.C. '
+      if (!user.isGovernment) {
+        byUser = ' by Government of B.C. '
+      }
     }
 
     let reportType = 'Model year report '

--- a/frontend/src/compliance/components/ComplianceHistory.js
+++ b/frontend/src/compliance/components/ComplianceHistory.js
@@ -185,9 +185,7 @@ const ComplianceHistory = (props) => {
                             ROUTES_SUPPLEMENTARY.SUPPLEMENTARY_DETAILS.replace(
                               ':id',
                               id
-                            ).replace(':supplementaryId', item.id) +
-                              (isReassessment ? '?reassessment=Y' : '') +
-                              `?tab=${tabName}`
+                            ).replace(':supplementaryId', item.id)
                           )
                         } else {
                           history.push(

--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -381,7 +381,6 @@ const SupplementaryAnalystDetails = (props) => {
             )}
         </div>
         {details &&
-          details.status === 'SUBMITTED' &&
           ((details.fromSupplierComments &&
             details.fromSupplierComments.length > 0) ||
             (details.attachments && details.attachments.length > 0)) && (

--- a/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
@@ -360,7 +360,6 @@ const SupplementaryDirectorDetails = (props) => {
               )}
         </div>
         {details &&
-          details.status === 'SUBMITTED' &&
           ((details.fromSupplierComments &&
             details.fromSupplierComments.length > 0) ||
             (details.attachments && details.attachments.length > 0)) && (


### PR DESCRIPTION
- for idir users the tab color is now correct when clicking through history to get to reassessent
- bottom bullet is removed for reassessments that have been recommended/issued (no longer shows when draft was saved)
-director name now shows up in history for assessed reassessments, for idir users only (previously showed up as assessed by government...)
-shows attachments to idir users
-changes text on headers for history components (ie Reassessment - REASSESSED instead of model year report Reassessment - reassessed, etc) 