### PR TITLE
fix - Zeva 1490 - history new release branch

### DIFF
--- a/frontend/src/compliance/components/ComplianceHistory.js
+++ b/frontend/src/compliance/components/ComplianceHistory.js
@@ -236,8 +236,8 @@ const ComplianceHistory = (props) => {
                       {item.history &&
                         getHistory(item.history).map((each, eachIndex) => (
                           <li
-                          id={`each-${eachIndex}`}
-                          key={`each-${eachIndex}`}
+                            id={`each-${eachIndex}`}
+                            key={`each-${eachIndex}`}
                           >
                             {getStatus(item, each)}
                           </li>


### PR DESCRIPTION
-for idir users the tab color is now correct when clicking through history to get to reassessent
-bottom bullet is removed for reassessments that have been recommended/issued (no longer shows when draft was saved director name now shows up in history for assessed reassessments, for idir users only (previously showed up as assessed by government...)
-shows attachments to idir users
-changes text on headers for history components (ie Reassessment - REASSESSED instead of model year report Reassessment - reassessed, etc)