### PR TITLE
fix: ZEVA - Incorrect credit balance being displayed on organization page #1517

### DIFF
--- a/backend/api/serializers/account_balance.py
+++ b/backend/api/serializers/account_balance.py
@@ -1,24 +1,26 @@
+## CAN BE REMOVED LATER
+
 """
 Account Balance Serializer
 """
-from rest_framework.serializers import ModelSerializer, SerializerMethodField
+# from rest_framework.serializers import ModelSerializer, SerializerMethodField
 
-from api.models.account_balance import AccountBalance
-from api.serializers.credit_transaction import CreditClassSerializer
-from api.serializers.user import MemberSerializer
+# from api.models.account_balance import AccountBalance
+# from api.serializers.credit_transaction import CreditClassSerializer
+# from api.serializers.user import MemberSerializer
 
 
-class AccountBalanceSerializer(ModelSerializer):
-    """
-    Serializer for balances
-    """
-    credit_class = CreditClassSerializer(read_only=True)
+# class AccountBalanceSerializer(ModelSerializer):
+#     """
+#     Serializer for balances
+#     """
+#     credit_class = CreditClassSerializer(read_only=True)
 
-    class Meta:
-        model = AccountBalance
-        fields = (
-            'id', 'create_timestamp', 'balance', 'credit_class',
-        )
-        read_only_fields = (
-            'id',
-        )
+#     class Meta:
+#         model = AccountBalance
+#         fields = (
+#             'id', 'create_timestamp', 'balance', 'credit_class',
+#         )
+#         read_only_fields = (
+#             'id',
+#         )

--- a/backend/api/serializers/model_year_report_assessment.py
+++ b/backend/api/serializers/model_year_report_assessment.py
@@ -1,17 +1,11 @@
-from datetime import date
-from django.db.models import Sum, Value, Q
 from rest_framework.serializers import ModelSerializer, \
-    SerializerMethodField, SlugRelatedField, CharField, \
-    ListField
-from api.models.account_balance import AccountBalance
-from api.models.credit_transaction import CreditTransaction
+    SerializerMethodField
 from api.models.model_year_report import ModelYearReport
 from api.models.model_year_report_assessment import ModelYearReportAssessment
 from api.models.model_year_report_assessment_comment import ModelYearReportAssessmentComment
 from api.serializers.model_year_report_assessment_comment import ModelYearReportAssessmentCommentSerializer
 from api.models.model_year_report_assessment_descriptions import ModelYearReportAssessmentDescriptions
 from api.models.model_year_report_compliance_obligation import ModelYearReportComplianceObligation
-from api.serializers.vehicle import ModelYearSerializer
 from api.models.model_year import ModelYear
 
 

--- a/backend/api/serializers/model_year_report_assessment_comment.py
+++ b/backend/api/serializers/model_year_report_assessment_comment.py
@@ -1,16 +1,8 @@
-from datetime import date
-from django.db.models import Sum, Value, Q
-from rest_framework import serializers
 from rest_framework.serializers import ModelSerializer, \
-    SerializerMethodField, SlugRelatedField, CharField, \
-    ListField
-from api.models.account_balance import AccountBalance
-from api.models.credit_transaction import CreditTransaction
-from api.models.model_year import ModelYear
-from api.models.model_year_report import ModelYearReport
+    SerializerMethodField
 from api.models.model_year_report_assessment_comment import ModelYearReportAssessmentComment
 from api.models.user_profile import UserProfile
-from api.serializers.user import MemberSerializer, UserSerializer
+from api.serializers.user import MemberSerializer
 
 
 class ModelYearReportAssessmentCommentSerializer(ModelSerializer):

--- a/backend/api/serializers/model_year_report_compliance_obligation.py
+++ b/backend/api/serializers/model_year_report_compliance_obligation.py
@@ -4,22 +4,23 @@ from api.models.model_year_report_credit_offset import ModelYearReportCreditOffs
 from api.serializers.vehicle import ModelYearSerializer
 
 
-class ModelYearReportComplianceObligationOutputSerializer(serializers.ModelSerializer):
-    model_year = ModelYearSerializer(read_only=True)
-    A = serializers.SerializerMethodField()
-    B = serializers.SerializerMethodField()
+## CAN BE REMOVED LATER
+# class ModelYearReportComplianceObligationOutputSerializer(serializers.ModelSerializer):
+#     model_year = ModelYearSerializer(read_only=True)
+#     A = serializers.SerializerMethodField()
+#     B = serializers.SerializerMethodField()
 
-    def get_A(self, obj, *args, **kwargs):
-        return obj.credit_a_value
+#     def get_A(self, obj, *args, **kwargs):
+#         return obj.credit_a_value
 
-    def get_B(self, obj, *args, **kwargs):
-        return obj.credit_b_value
+#     def get_B(self, obj, *args, **kwargs):
+#         return obj.credit_b_value
 
-    class Meta:
-        model = ModelYearReportComplianceObligation
-        fields = (
-            'model_year', 'A', 'B'
-        )
+#     class Meta:
+#         model = ModelYearReportComplianceObligation
+#         fields = (
+#             'model_year', 'A', 'B'
+#         )
 
 
 class ModelYearReportComplianceObligationOffsetSerializer(serializers.ModelSerializer):
@@ -43,13 +44,14 @@ class ModelYearReportComplianceObligationSnapshotSerializer(serializers.ModelSer
             'category', 'model_year', 'update_timestamp',
         )
 
-class ModelYearReportComplianceObligationSaveSerializer(serializers.ModelSerializer):
-    model_year = ModelYearSerializer()
+## CAN BE REMOVED LATER
+# class ModelYearReportComplianceObligationSaveSerializer(serializers.ModelSerializer):
+#     model_year = ModelYearSerializer()
 
-    def create(self, obj, validated_data):
-        return obj
+#     def create(self, obj, validated_data):
+#         return obj
 
-    class Meta:
-        model = ModelYearReportComplianceObligation
-        fields = ('model_year_report', 'model_year', 'credit_a_value',
-                  'credit_b_value', 'category')
+#     class Meta:
+#         model = ModelYearReportComplianceObligation
+#         fields = ('model_year_report', 'model_year', 'credit_a_value',
+#                   'credit_b_value', 'category')

--- a/backend/api/serializers/model_year_report_compliance_obligation.py
+++ b/backend/api/serializers/model_year_report_compliance_obligation.py
@@ -178,19 +178,6 @@ class ModelYearReportComplianceObligationSnapshotSerializer(serializers.ModelSer
     #         'report_year_balance', 'pending_balance', 'prior_year_balance', 'report_year_transactions'
     #     )
 
-# class ModelYearReportComplianceObligationSaveSerializer(serializers.ModelSerializer):
-#     model_year = ModelYearSerializer()
-
-#     def create(self, validated_data):
-#         return obj
-
-#     class Meta:
-#         model = ModelYearReportComplianceObligation
-#         fields = ('model_year_report', 'model_year', 'credit_a_value',
-#                   'credit_b_value', 'category')
-       
-
-
 
 ## CAN BE REMOVED LATER
 # class ModelYearReportComplianceObligationSaveSerializer(serializers.ModelSerializer):

--- a/backend/api/serializers/model_year_report_compliance_obligation.py
+++ b/backend/api/serializers/model_year_report_compliance_obligation.py
@@ -1,15 +1,6 @@
-from datetime import date
-from django.db.models import Sum, Value
 from rest_framework import serializers
-from api.models.account_balance import AccountBalance
-from api.models.credit_transaction import CreditTransaction
-from api.models.model_year import ModelYear
-from api.models.model_year_report import ModelYearReport
 from api.models.model_year_report_compliance_obligation import ModelYearReportComplianceObligation
 from api.models.model_year_report_credit_offset import ModelYearReportCreditOffset
-from api.models.sales_submission import SalesSubmission
-from api.models.vehicle import Vehicle
-from api.models.vehicle_statuses import VehicleDefinitionStatuses
 from api.serializers.vehicle import ModelYearSerializer
 
 
@@ -52,144 +43,10 @@ class ModelYearReportComplianceObligationSnapshotSerializer(serializers.ModelSer
             'category', 'model_year', 'update_timestamp',
         )
 
-
-class ModelYearReportComplianceObligationDetailsSerializer(serializers.ModelSerializer):
-    """
-    """
-    prior_year_balance = serializers.SerializerMethodField()
-    report_year_balance = serializers.SerializerMethodField()
-    report_year_transactions = serializers.SerializerMethodField()
-    pending_balance = serializers.SerializerMethodField()
-    def retrieve_year(self, report_id):
-        report = ModelYearReport.objects.get(
-            id=report_id
-        )
-        report_year_obj = ModelYear.objects.get(
-            id=report.model_year_id
-        )
-        report_year = int(report_year_obj.name)
-        return report_year
-
-    def retrieve_balance(self, year, credit_type):
-        request = self.context.get('request')
-        balance = AccountBalance.objects.filter(
-            organization=request.user.organization,
-            effective_date__lte=date(year, 9, 30),
-            credit_class_id=credit_type
-        ).order_by('-effective_date').first()
-        if balance:
-            return balance.balance
-        else:
-            return 0
-
-    def get_prior_year_balance(self, obj, *args, **kwargs):
-        ## this needs to change to grab to grab values from the prior year snapshot
-        kwargs = self.context.get('kwargs')
-        report_id = int(kwargs.get('id'))
-        report_year = self.retrieve_year(report_id)
-        prior_year = report_year-1
-        prior_year_balance_a = self.retrieve_balance(prior_year, 1)
-        prior_year_balance_b = self.retrieve_balance(prior_year, 2)
-        return {'year': prior_year, 'A': prior_year_balance_a, 'B': prior_year_balance_b}
-
-    # def get_report_year_transactions(self, obj, *args, **kwargs):
-    #     request = self.context.get('request')
-    #     kwargs = self.context.get('kwargs')
-    #     report_id = int(kwargs.get('id'))
-    #     report_year = self.retrieve_year(report_id)
-
-    #     transfers_in = CreditTransaction.objects.filter(
-    #         credit_to=request.user.organization,
-    #         transaction_type__transaction_type='Credit Transfer',
-    #         transaction_timestamp__lte=date(report_year, 9, 30),
-    #         transaction_timestamp__gte=date(report_year-1, 10, 1),
-    #     ).values(
-    #         'credit_class_id', 'model_year_id'
-    #     ).annotate(
-    #         total_value=Sum('total_value')
-    #     ).order_by(
-    #         'credit_class_id', 'model_year_id'
-    #     )
-        
-    #     transfers_out = CreditTransaction.objects.filter(
-    #         debit_from=request.user.organization,
-    #         transaction_type__transaction_type='Credit Transfer',
-    #         transaction_timestamp__lte=date(report_year, 9, 30),
-    #         transaction_timestamp__gte=date(report_year-1, 10, 1),
-    #     ).values(
-    #         'credit_class_id', 'model_year_id'
-    #     ).annotate(total_value=Sum(
-    #         'total_value')
-    #     ).order_by(
-    #         'credit_class_id', 'model_year_id'
-    #     )
-
-    #     credits_issued_sales = CreditTransaction.objects.filter(
-    #         credit_to=request.user.organization,
-    #         transaction_type__transaction_type='Validation',
-    #         transaction_timestamp__lte=date(report_year, 9, 30),
-    #         transaction_timestamp__gte=date(report_year-1, 10, 1),
-    #     ).values(
-    #         'credit_class_id', 'model_year_id'
-    #     ).annotate(
-    #         total_value=Sum('total_value')
-    #     ).order_by(
-    #         'credit_class_id', 'model_year_id'
-    #     )
-
-    #     transfers_in_serializer = CreditTransactionObligationActivitySerializer(transfers_in, read_only=True, many=True)
-    #     transfers_out_serializer = CreditTransactionObligationActivitySerializer(transfers_out, read_only=True, many=True)
-    #     credit_sales_serializer = CreditTransactionObligationActivitySerializer(credits_issued_sales, read_only=True, many=True)
-    #     content = {
-    #         'transfers_in': transfers_in_serializer.data,
-    #         'transfers_out': transfers_out_serializer.data,
-    #         'credits_issued_sales': credit_sales_serializer.data,
-    #         'adjustments_validation': adjustments_validation_serializer.data,
-    #         'adjustments_reduction': adjustments_reduction_serializer.data
-    #         }
-    #     return content
-
-    def get_pending_balance(self, obj, *args, **kwargs):
-        kwargs = self.context.get('kwargs')
-        report_id = int(kwargs.get('id'))
-        report_year = self.retrieve_year(report_id)
-        request = self.context.get('request')
-        pending_sales_submissions = SalesSubmission.objects.filter(
-            organization=request.user.organization,
-            validation_status__in=['SUBMITTED', 'RECOMMEND_APPROVAL', 'RECOMMEND_REJECTION', 'CHECKED']
-        )
-        totals = {}
-        for obj in pending_sales_submissions:
-            for record in obj.get_content_totals_by_vehicles():
-                try:
-                    model_year = float(record['xls_model_year'])
-                except ValueError:
-                    continue
-                if int(model_year) != int(report_year):
-                    continue
-                vehicle = Vehicle.objects.filter(
-                    make__iexact=record['xls_make'],
-                    model_name=record['xls_model'],
-                    model_year__name=int(model_year),
-                    validation_status=VehicleDefinitionStatuses.VALIDATED,
-                ).first()
-                if vehicle:
-                    model_year_str = str(int(model_year))
-                    if model_year_str not in totals.keys():
-                        totals[model_year_str] = {'A': 0, 'B': 0}
-                    totals[model_year_str][vehicle.get_credit_class()] += vehicle.get_credit_value() * record['num_vins']
-        return totals
-
-    class Meta:
-        model = CreditTransaction
-        fields = (
-            'report_year_balance', 'pending_balance', 'prior_year_balance', 'report_year_transactions'
-        )
-
 class ModelYearReportComplianceObligationSaveSerializer(serializers.ModelSerializer):
     model_year = ModelYearSerializer()
 
-    def create(self, validated_data):
+    def create(self, obj, validated_data):
         return obj
 
     class Meta:

--- a/backend/api/serializers/model_year_report_compliance_obligation.py
+++ b/backend/api/serializers/model_year_report_compliance_obligation.py
@@ -33,6 +33,18 @@ class ModelYearReportComplianceObligationOffsetSerializer(serializers.ModelSeria
             'model_year', 'model_year_report'
         )
 
+
+class ModelYearReportComplianceObligationSnapshotSerializer(serializers.ModelSerializer):
+    model_year = ModelYearSerializer(read_only=True)
+
+    class Meta:
+        model = ModelYearReportComplianceObligation
+        fields = (
+            'credit_a_value',  'credit_b_value',
+            'category', 'model_year', 'update_timestamp',
+        )
+
+
 # class ModelYearReportComplianceObligationDetailsSerializer(serializers.ModelSerializer):
 #     """
 #     """
@@ -178,15 +190,7 @@ class ModelYearReportComplianceObligationOffsetSerializer(serializers.ModelSeria
 #                   'credit_b_value', 'category')
        
 
-class ModelYearReportComplianceObligationSnapshotSerializer(serializers.ModelSerializer):
-    model_year = ModelYearSerializer(read_only=True)
 
-    class Meta:
-        model = ModelYearReportComplianceObligation
-        fields = (
-            'credit_a_value',  'credit_b_value',
-            'category', 'model_year', 'update_timestamp',
-        )
 
 ## CAN BE REMOVED LATER
 # class ModelYearReportComplianceObligationSaveSerializer(serializers.ModelSerializer):

--- a/backend/api/serializers/model_year_report_compliance_obligation.py
+++ b/backend/api/serializers/model_year_report_compliance_obligation.py
@@ -33,6 +33,150 @@ class ModelYearReportComplianceObligationOffsetSerializer(serializers.ModelSeria
             'model_year', 'model_year_report'
         )
 
+# class ModelYearReportComplianceObligationDetailsSerializer(serializers.ModelSerializer):
+#     """
+#     """
+#     prior_year_balance = serializers.SerializerMethodField()
+#     report_year_balance = serializers.SerializerMethodField()
+#     report_year_transactions = serializers.SerializerMethodField()
+#     pending_balance = serializers.SerializerMethodField()
+#     def retrieve_year(self, report_id):
+#         report = ModelYearReport.objects.get(
+#             id=report_id
+#         )
+#         report_year_obj = ModelYear.objects.get(
+#             id=report.model_year_id
+#         )
+#         report_year = int(report_year_obj.name)
+#         return report_year
+
+#     def retrieve_balance(self, year, credit_type):
+#         request = self.context.get('request')
+#         balance = AccountBalance.objects.filter(
+#             organization=request.user.organization,
+#             effective_date__lte=date(year, 9, 30),
+#             credit_class_id=credit_type
+#         ).order_by('-effective_date').first()
+#         if balance:
+#             return balance.balance
+#         else:
+#             return 0
+
+#     def get_prior_year_balance(self, obj, *args, **kwargs):
+#         ## this needs to change to grab to grab values from the prior year snapshot
+#         kwargs = self.context.get('kwargs')
+#         report_id = int(kwargs.get('id'))
+#         report_year = self.retrieve_year(report_id)
+#         prior_year = report_year-1
+#         prior_year_balance_a = self.retrieve_balance(prior_year, 1)
+#         prior_year_balance_b = self.retrieve_balance(prior_year, 2)
+#         return {'year': prior_year, 'A': prior_year_balance_a, 'B': prior_year_balance_b}
+
+    # def get_report_year_transactions(self, obj, *args, **kwargs):
+    #     request = self.context.get('request')
+    #     kwargs = self.context.get('kwargs')
+    #     report_id = int(kwargs.get('id'))
+    #     report_year = self.retrieve_year(report_id)
+
+    #     transfers_in = CreditTransaction.objects.filter(
+    #         credit_to=request.user.organization,
+    #         transaction_type__transaction_type='Credit Transfer',
+    #         transaction_timestamp__lte=date(report_year, 9, 30),
+    #         transaction_timestamp__gte=date(report_year-1, 10, 1),
+    #     ).values(
+    #         'credit_class_id', 'model_year_id'
+    #     ).annotate(
+    #         total_value=Sum('total_value')
+    #     ).order_by(
+    #         'credit_class_id', 'model_year_id'
+    #     )
+
+    #     transfers_out = CreditTransaction.objects.filter(
+    #         debit_from=request.user.organization,
+    #         transaction_type__transaction_type='Credit Transfer',
+    #         transaction_timestamp__lte=date(report_year, 9, 30),
+    #         transaction_timestamp__gte=date(report_year-1, 10, 1),
+    #     ).values(
+    #         'credit_class_id', 'model_year_id'
+    #     ).annotate(total_value=Sum(
+    #         'total_value')
+    #     ).order_by(
+    #         'credit_class_id', 'model_year_id'
+    #     )
+
+    #     credits_issued_sales = CreditTransaction.objects.filter(
+    #         credit_to=request.user.organization,
+    #         transaction_type__transaction_type='Validation',
+    #         transaction_timestamp__lte=date(report_year, 9, 30),
+    #         transaction_timestamp__gte=date(report_year-1, 10, 1),
+    #     ).values(
+    #         'credit_class_id', 'model_year_id'
+    #     ).annotate(
+    #         total_value=Sum('total_value')
+    #     ).order_by(
+    #         'credit_class_id', 'model_year_id'
+    #     )
+
+    #     transfers_in_serializer = CreditTransactionObligationActivitySerializer(transfers_in, read_only=True, many=True)
+    #     transfers_out_serializer = CreditTransactionObligationActivitySerializer(transfers_out, read_only=True, many=True)
+    #     credit_sales_serializer = CreditTransactionObligationActivitySerializer(credits_issued_sales, read_only=True, many=True)
+    #     content = {
+    #         'transfers_in': transfers_in_serializer.data,
+    #         'transfers_out': transfers_out_serializer.data,
+    #         'credits_issued_sales': credit_sales_serializer.data,
+    #         'adjustments_validation': adjustments_validation_serializer.data,
+    #         'adjustments_reduction': adjustments_reduction_serializer.data
+    #         }
+    #     return content
+
+    # def get_pending_balance(self, obj, *args, **kwargs):
+    #     kwargs = self.context.get('kwargs')
+    #     report_id = int(kwargs.get('id'))
+    #     report_year = self.retrieve_year(report_id)
+    #     request = self.context.get('request')
+    #     pending_sales_submissions = SalesSubmission.objects.filter(
+    #         organization=request.user.organization,
+    #         validation_status__in=['SUBMITTED', 'RECOMMEND_APPROVAL', 'RECOMMEND_REJECTION', 'CHECKED']
+    #     )
+    #     totals = {}
+    #     for obj in pending_sales_submissions:
+    #         for record in obj.get_content_totals_by_vehicles():
+    #             try:
+    #                 model_year = float(record['xls_model_year'])
+    #             except ValueError:
+    #                 continue
+    #             if int(model_year) != int(report_year):
+    #                 continue
+    #             vehicle = Vehicle.objects.filter(
+    #                 make__iexact=record['xls_make'],
+    #                 model_name=record['xls_model'],
+    #                 model_year__name=int(model_year),
+    #                 validation_status=VehicleDefinitionStatuses.VALIDATED,
+    #             ).first()
+    #             if vehicle:
+    #                 model_year_str = str(int(model_year))
+    #                 if model_year_str not in totals.keys():
+    #                     totals[model_year_str] = {'A': 0, 'B': 0}
+    #                 totals[model_year_str][vehicle.get_credit_class()] += vehicle.get_credit_value() * record['num_vins']
+    #     return totals
+
+    # class Meta:
+    #     model = CreditTransaction
+    #     fields = (
+    #         'report_year_balance', 'pending_balance', 'prior_year_balance', 'report_year_transactions'
+    #     )
+
+# class ModelYearReportComplianceObligationSaveSerializer(serializers.ModelSerializer):
+#     model_year = ModelYearSerializer()
+
+#     def create(self, validated_data):
+#         return obj
+
+#     class Meta:
+#         model = ModelYearReportComplianceObligation
+#         fields = ('model_year_report', 'model_year', 'credit_a_value',
+#                   'credit_b_value', 'category')
+       
 
 class ModelYearReportComplianceObligationSnapshotSerializer(serializers.ModelSerializer):
     model_year = ModelYearSerializer(read_only=True)

--- a/backend/api/viewsets/model_year_report_compliance_obligation.py
+++ b/backend/api/viewsets/model_year_report_compliance_obligation.py
@@ -31,7 +31,6 @@ from api.models.model_year_report_ldv_sales import \
     ModelYearReportLDVSales
 from api.permissions.model_year_report import ModelYearReportPermissions
 from api.serializers.model_year_report_compliance_obligation import \
-    ModelYearReportComplianceObligationDetailsSerializer, \
     ModelYearReportComplianceObligationSnapshotSerializer, \
     ModelYearReportComplianceObligationOffsetSerializer
 from api.serializers.credit_transaction import \
@@ -54,8 +53,7 @@ class ModelYearReportComplianceObligationViewset(
     http_method_names = ['get', 'post', 'put', 'patch']
 
     serializer_classes = {
-        'default': ModelYearReportComplianceObligationDetailsSerializer,
-        'details': ModelYearReportComplianceObligationDetailsSerializer,
+
     }
 
     def get_queryset(self):

--- a/frontend/src/compliance/components/ConsumerSalesLDVModelTable.js
+++ b/frontend/src/compliance/components/ConsumerSalesLDVModelTable.js
@@ -4,8 +4,12 @@ import ReactTable from '../../app/components/ReactTable'
 
 const ConsumerSalesLDVModalTable = (props) => {
   const { vehicles } = props
-  const totalPendingSales = vehicles.map(v => v.pendingSales).reduce((a, b) => a + b)
-  const totalSalesIssued = vehicles.map(v => v.salesIssued).reduce((a, b) => a + b)
+  let totalPendingSales
+  let totalSalesIssued
+  if (vehicles.length > 0) {
+    totalSalesIssued = vehicles.map(v => v.salesIssued).reduce((a, b) => a + b)
+    totalPendingSales = vehicles.map(v => v.pendingSales).reduce((a, b) => a + b)
+  }
 
   const columns = [
     {


### PR DESCRIPTION
fix: changes organization model method to use transactions to calculate balance rather than acount balance table
chore: removes unused serializer from compliance obligation (there are still some unused serializers here...
chore: removes unused references from some files
fix:adds check for array length in consumer sales ldv model table (was causing error if list length is 0)