### PR TITLE
fix: zeva 1567 - comments not visible and list page showing supplemental returned

### DIFF
--- a/backend/api/serializers/model_year_report.py
+++ b/backend/api/serializers/model_year_report.py
@@ -330,9 +330,8 @@ class ModelYearReportListSerializer(ModelSerializer, EnumSupportSerializerMixin)
 
                 if create_user.is_government:
                     if sup_status == "RETURNED":
-                        # this record was created by idir but
-                        # should show up as supplementary returned
-                        return ("SUPPLEMENTARY {}").format(sup_status)
+                        return ("REASSESSMENT {}").format(sup_status)
+
                     if sup_status == "REASSESSED" or sup_status == "ASSESSED":
                         # bceid and idir can see just 'reassessed' as status
                         return "REASSESSED"

--- a/backend/api/viewsets/model_year_report.py
+++ b/backend/api/viewsets/model_year_report.py
@@ -729,7 +729,6 @@ class ModelYearReportViewset(
     @action(detail=True, methods=["get"])
     def supplemental_assessment(self, request, pk):
         report = get_object_or_404(ModelYearReport, pk=pk)
-
         if report.supplemental is None:
             serializer = SupplementalReportAssessmentSerializer(
                 0, context={"request": request}
@@ -756,11 +755,11 @@ class ModelYearReportViewset(
                 ):
                     supplemental_id = 0
 
-                if supplemental_report.status.value in ["RETURNED", "DELETED"]:
+                if supplemental_report.status.value in ["DELETED"]:
                     supplemental_id = 0
             elif supplemental_report and not request.user.is_government:
                 if (
-                    supplemental_report.status.value == "DRAFT"
+                    supplemental_report.status.value in ["DRAFT", "RETURNED"]
                     and create_user.is_government
                 ):
                     supplemental_id = 0

--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -609,7 +609,7 @@ const SupplementaryAnalystDetails = (props) => {
               )}
               {CONFIG.FEATURES.SUPPLEMENTAL_REPORT.ENABLED &&
                 isEditable &&
-                ['DRAFT', 'SUBMITTED'].indexOf(details.status) >= 0 &&
+                ['DRAFT', 'SUBMITTED', 'RETURNED'].indexOf(details.status) >= 0 &&
                 (
                   <Button
                     buttonTooltip={recommendTooltip}


### PR DESCRIPTION
fix: changes returned reports in the list page to say 'reassessment returned' instead of 'supplementary returned'
fix: comments on returned supplementary were not visible, the viewset was passing 0 as the supplementary id for returned status, it now passes the correct id so comments display. 