### PR TITLE
fix zeva 1567 continued - service/records address changes from reassessment not appearing on reassessment page

### DIFF
--- a/frontend/src/compliance/components/AssessmentDetailsPage.js
+++ b/frontend/src/compliance/components/AssessmentDetailsPage.js
@@ -400,7 +400,6 @@ const AssessmentDetailsPage = (props) => {
             <NoticeOfAssessmentSection
               name={details.organization.name}
               addresses={details.organization.organizationAddress}
-              addressesAreStrings={false}
               makes={makes}
               supplierClass={supplierClass}
               disabledInputs={disabledInputs}

--- a/frontend/src/compliance/components/NoticeOfAssessmentSection.js
+++ b/frontend/src/compliance/components/NoticeOfAssessmentSection.js
@@ -23,10 +23,11 @@ const NoticeOfAssessmentSection = ({
     let formattedAddress
     addresses.forEach((address) => {
       if (address.addressType.addressType === type) {
-        formattedAddress = (<div key={addresses.id}>
-          {address.representativeName && (
-            <div> {address.representativeName} </div>
-          )}
+        formattedAddress = (
+          <div key={addresses.id}>
+            {address.representativeName && (
+              <div> {address.representativeName} </div>
+            )}
             <div> {address.addressLine1} </div>
             <div> {address.addressLine2} </div>
             <div>
@@ -34,7 +35,7 @@ const NoticeOfAssessmentSection = ({
               {address.city} {address.state} {address.country}{' '}
             </div>
             <div> {address.postalCode} </div>
-            </div>
+          </div>
         )
       }
     }

--- a/frontend/src/compliance/components/NoticeOfAssessmentSection.js
+++ b/frontend/src/compliance/components/NoticeOfAssessmentSection.js
@@ -3,10 +3,11 @@ import React from 'react'
 const NoticeOfAssessmentSection = ({
   name,
   addresses,
-  addressesAreStrings,
   makes,
   supplierClass,
-  disabledInputs
+  disabledInputs,
+  reassessmentServiceAddress,
+  reassessmentRecordsAddress
 }) => {
   const getClassDescriptions = (_supplierClass) => {
     switch (_supplierClass) {
@@ -18,64 +19,57 @@ const NoticeOfAssessmentSection = ({
         return 'Small'
     }
   }
+  const getAddress = (type) => {
+    let formattedAddress
+    addresses.forEach((address) => {
+      if (address.addressType.addressType === type) {
+        formattedAddress = (<div key={addresses.id}>
+          {address.representativeName && (
+            <div> {address.representativeName} </div>
+          )}
+            <div> {address.addressLine1} </div>
+            <div> {address.addressLine2} </div>
+            <div>
+              {' '}
+              {address.city} {address.state} {address.country}{' '}
+            </div>
+            <div> {address.postalCode} </div>
+            </div>
+        )
+      }
+    }
+    )
+    return formattedAddress
+  }
+
   return (
     <>
       <h3>Notice of Assessment</h3>
       <div className="mt-3">
         <h3> {name} </h3>
       </div>
-      {addressesAreStrings && addresses && addresses.length > 0 && (
+      {(addresses || reassessmentRecordsAddress || reassessmentServiceAddress) && (
         <div>
           <div className="d-inline-block mr-5 mt-3 col-5 text-blue">
             <h4>Service Address</h4>
-            <div>{addresses[0]}</div>
-          </div>
-          <div className="d-inline-block mr-5 mt-3 col-5 text-blue">
-            <h4>Records Address</h4>
-            <div>{addresses[1]}</div>
-          </div>
-        </div>
-      )}
-      {!addressesAreStrings && addresses && addresses.length > 0 && (
-        <div>
-          <div className="d-inline-block mr-5 mt-3 col-5 text-blue">
-            <h4>Service Address</h4>
-            {addresses.map(
-              (address) =>
-                address.addressType.addressType === 'Service' && (
-                  <div key={address.id}>
-                    {address.representativeName && (
-                      <div> {address.representativeName} </div>
-                    )}
-                    <div> {address.addressLine1} </div>
-                    <div> {address.addressLine2} </div>
-                    <div>
-                      {' '}
-                      {address.city} {address.state} {address.country}{' '}
-                    </div>
-                    <div> {address.postalCode} </div>
-                  </div>
-                )
+            {reassessmentServiceAddress && (
+              <div>{reassessmentServiceAddress}</div>
+            )}
+            {!reassessmentServiceAddress && (
+              <>
+              {getAddress('Service')}
+              </>
             )}
           </div>
           <div className="d-inline-block mt-3 col-xs-12 col-sm-5 text-blue">
             <h4>Records Address</h4>
-            {addresses.map(
-              (address) =>
-                address.addressType.addressType === 'Records' && (
-                  <div key={address.id}>
-                    {address.representativeName && (
-                      <div> {address.representativeName} </div>
-                    )}
-                    <div> {address.addressLine1} </div>
-                    <div> {address.addressLine2} </div>
-                    <div>
-                      {' '}
-                      {address.city} {address.state} {address.country}{' '}
-                    </div>
-                    <div> {address.postalCode} </div>
-                  </div>
-                )
+            {reassessmentRecordsAddress && (
+              <div>{reassessmentRecordsAddress}</div>
+            )}
+            {!reassessmentRecordsAddress && (
+              <>
+                {getAddress('Records')}
+              </>
             )}
           </div>
         </div>

--- a/frontend/src/supplementary/components/ReassessmentDetailsPage.js
+++ b/frontend/src/supplementary/components/ReassessmentDetailsPage.js
@@ -28,24 +28,15 @@ const ReassessmentDetailsPage = (props) => {
   if (newData && newData.supplierInfo && newData.supplierInfo.legalName) {
     supplierName = newData.supplierInfo.legalName
   }
-
-  let addresses = details.assessmentData.reportAddress
-  let addressesAreStrings = false
-  if (
-    newData &&
-    newData.supplierInfo &&
-    newData.supplierInfo.recordsAddress &&
-    typeof newData.supplierInfo.recordsAddress === 'string' &&
-    newData.supplierInfo.serviceAddress &&
-    typeof newData.supplierInfo.serviceAddress === 'string'
-  ) {
-    addressesAreStrings = true
-    addresses = [
-      newData.supplierInfo.serviceAddress,
-      newData.supplierInfo.recordsAddress
-    ]
+  const addresses = details.assessmentData.reportAddress
+  let reassessmentRecordsAddress
+  let reassessmentServiceAddress
+  if (newData.supplierInfo && newData.supplierInfo.recordsAddress) {
+    reassessmentRecordsAddress = newData.supplierInfo.recordsAddress
   }
-
+  if (newData.supplierInfo && newData.supplierInfo.serviceAddress) {
+    reassessmentServiceAddress = newData.supplierInfo.serviceAddress
+  }
   let makes = details.assessmentData.makes
   if (newData && newData.supplierInfo && newData.supplierInfo.ldvMakes) {
     makes = newData.supplierInfo.ldvMakes.split('\n')
@@ -233,7 +224,8 @@ const ReassessmentDetailsPage = (props) => {
       <NoticeOfAssessmentSection
         name={supplierName}
         addresses={addresses}
-        addressesAreStrings={addressesAreStrings}
+        reassessmentServiceAddress={reassessmentServiceAddress}
+        reassessmentRecordsAddress={reassessmentRecordsAddress}
         makes={makes}
         supplierClass={supplierClass}
         disabledInputs={false}


### PR DESCRIPTION
-fix: address reassessment addresses to reassessment page / refactors notice of assessment
-splits up records/service addresses in the details page so that they are handled separately