### PR TITLE
chore: zeva-1499 - SupplementaryAnalystDetails unit tests

### DIFF
--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -129,6 +129,7 @@ const SupplementaryAnalystDetails = (props) => {
           disabled={
             ['RECOMMENDED', 'ASSESSED'].indexOf(currentStatus) >= 0
           }
+          data-testid={'recommendation-' + each.id}
           onChange={() => {
             setSupplementaryAssessmentData({
               ...supplementaryAssessmentData,
@@ -584,7 +585,7 @@ const SupplementaryAnalystDetails = (props) => {
               {CONFIG.FEATURES.SUPPLEMENTAL_REPORT.ENABLED &&
                 selectedTab === tabNames[1] &&
                 ['DRAFT'].indexOf(details.status) < 0 &&
-                !supplementaryReportId === null &&
+                supplementaryReportId !== null &&
                 (isEditable ||
                   ['SUBMITTED'].indexOf(details.status) >= 0) &&
                     <button
@@ -593,6 +594,7 @@ const SupplementaryAnalystDetails = (props) => {
                         handleSubmit('DRAFT')
                       }}
                       type="button"
+                      data-testid="return-button"
                     >
                       Return to Vehicle Supplier
                     </button>
@@ -606,6 +608,7 @@ const SupplementaryAnalystDetails = (props) => {
                     action={() => {
                       handleSubmit(currentStatus, false)
                     }}
+                    testid="save-button"
                   />
               )}
               {CONFIG.FEATURES.SUPPLEMENTAL_REPORT.ENABLED &&
@@ -621,6 +624,7 @@ const SupplementaryAnalystDetails = (props) => {
                     action={() => {
                       handleSubmit('RECOMMENDED')
                     }}
+                    testid="recommend-button"
                   />
                 )}
 

--- a/frontend/src/supplementary/components/__tests__/SupplementaryAnalystDetails.test.js
+++ b/frontend/src/supplementary/components/__tests__/SupplementaryAnalystDetails.test.js
@@ -1,8 +1,10 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import SupplementaryAnalystDetails from '../SupplementaryAnalystDetails'
 import '@testing-library/jest-dom/extend-expect'
 import { BrowserRouter as Router } from 'react-router-dom'
+import CONFIG from '../../../app/config'
+
 const testFunction = () => {}
 const commentArray = {
   bdeidComment: [],
@@ -23,7 +25,7 @@ const commentArray = {
     }
   }]
 }
-const details = {
+const baseDetails = {
   assessmentData: {
     makes: ['make1', 'make2'],
     modelYear: '2021',
@@ -53,7 +55,8 @@ const details = {
       state: 'BC'
     }],
     creditReductionSelection: 'A'
-  }
+  },
+  actualStatus: 'DRAFT'
 }
 const newData = {}
 const radioDescriptions = [{
@@ -75,7 +78,7 @@ const salesRows = [
   { newData: {}, oldData: { creditAValue: '10.00', creditBValue: '10.00', modelYear: '2021', category: 'creditBalanceStart' } }
 ]
 
-const obligationDetails = [
+const baseObligationDetails = [
   {
     creditClass: { creditClass: 'A' },
     detailTransactionType: null,
@@ -91,72 +94,316 @@ const obligationDetails = [
   }
 ]
 
+const baseUser = {
+  isGovernment: true
+}
+
+const baseProps = {
+  addSalesRow: testFunction,
+  commentArray,
+  deleteFiles: [{}],
+  details: baseDetails,
+  handleAddIdirComment: testFunction,
+  handleCommentChangeBceid: testFunction,
+  handleCommentChangeIdir: testFunction,
+  handleDeleteIdirComment: testFunction,
+  handleEditIdirComment: testFunction,
+  handleInputChange: testFunction,
+  handleSubmit: testFunction,
+  handleSupplementalChange: testFunction,
+  id: 1,
+  loading: false,
+  ldvSales: 1000,
+  newData,
+  newBalances: {},
+  ratios: {
+    complianceRatio: 12.00,
+    modelYear: '2021',
+    id: 1,
+    zevClassA: 8.00
+  },
+  obligationDetails: baseObligationDetails,
+  radioDescriptions,
+  salesRows,
+  setSupplementaryAssessmentData: testFunction,
+  supplementaryAssessmentData: {
+    supplementaryAssessment: {
+      penalty: 0,
+      decision: { description: '{user.organization.name} has not complied.', id: 3 },
+      inCompliance: false
+    }
+  },
+  user: baseUser
+}
+
+const mockSupplementaryTabPropsTracker = jest.fn()
+jest.mock('../SupplementaryTab', () => {
+  const SupplementaryTabMock = (props) => {
+    mockSupplementaryTabPropsTracker(props)
+    return <div>SupplementaryTabMock</div>
+  }
+  return SupplementaryTabMock
+})
+
+const mockSupplierInformationPropsTracker = jest.fn()
+jest.mock('../SupplierInformation', () => {
+  const SupplierInformationMock = (props) => {
+    mockSupplierInformationPropsTracker(props)
+    return <div>SupplierInformationMock</div>
+  }
+  return SupplierInformationMock
+})
+
+const mockZevSalesPropsTracker = jest.fn()
+jest.mock('../ZevSales', () => {
+  const ZevSalesMock = (props) => {
+    mockZevSalesPropsTracker(props)
+    return <div>ZevSalesMock</div>
+  }
+  return ZevSalesMock
+})
+
+const mockCreditActivityPropsTracker = jest.fn()
+jest.mock('../CreditActivity', () => {
+  const CreditActivityMock = (props) => {
+    mockCreditActivityPropsTracker(props)
+    return <div>CreditActivityMock</div>
+  }
+  return CreditActivityMock
+})
+
+const mockCommentInputPropsTracker = jest.fn()
+jest.mock('../../../app/components/CommentInput', () => {
+  const CommentInputMock = (props) => {
+    mockCommentInputPropsTracker(props)
+    return <div>CommentInputMock</div>
+  }
+  return CommentInputMock
+})
+
+jest.mock('../UploadEvidence', () => {
+  const UploadEvidenceMock = () => <div>UploadEvidenceMock</div>
+  return UploadEvidenceMock
+})
+
+afterEach(() => {
+  mockSupplementaryTabPropsTracker.mockClear()
+  mockSupplierInformationPropsTracker.mockClear()
+  mockZevSalesPropsTracker.mockClear()
+  mockCreditActivityPropsTracker.mockClear()
+  mockCommentInputPropsTracker.mockClear()
+})
+
+jest.replaceProperty(CONFIG.FEATURES.SUPPLEMENTAL_REPORT, 'ENABLED', true)
+
 describe('SupplementaryAnalystDetails', () => {
   it('renders without crashing', () => {
     render(
       <Router>
         <SupplementaryAnalystDetails
-          addSalesRow={testFunction}
-          commentArray={commentArray}
-          deleteFiles={[{}]}
-          details={details}
-          handleAddIdirComment={testFunction}
-          handleCommentChangeBceid={testFunction}
-          handleCommentChangeIdir={testFunction}
-          handleDeleteIdirComment={testFunction}
-          handleEditIdirComment={testFunction}
-          handleInputChange={testFunction}
-          handleSubmit={testFunction}
-          handleSupplementalChange={testFunction}
-          id={1}
-          loading={false}
-          ldvSales={1000}
-          newData={newData}
-          newBalances={{}}
-          ratios={{
-            complianceRatio: 12.00,
-            modelYear: '2021',
-            id: 1,
-            zevClassA: 8.00
-          }}
-          obligationDetails={obligationDetails}
-          radioDescriptions={radioDescriptions}
-          salesRows={salesRows}
-          setSupplementaryAssessmentData={testFunction}
-          supplementaryAssessmentData={
-              {
-                supplementaryAssessment: {
-                  penalty: 0,
-                  decision: { description: '{user.organization.name} has not complied.', id: 3 },
-                  inCompliance: false
-                }
-              }
-            }
-          user={{ isGovernment: true }}
+          {...baseProps}
         />
       </Router>
     )
   })
+
+  test('as an analyst, if i view a supplemental report in submitted status, i should be able to edit fields, add comments to supplier or director, click a radio button for the assessment, and save/recommend to director or return to supplier', () => {
+    const details = { ...baseDetails, actualStatus: 'SUBMITTED', status: 'SUBMITTED' }
+    const mockSetSupplementaryAssessmentData = jest.fn()
+    const mockhandleSubmit = jest.fn()
+    const props = { ...baseProps, details, setSupplementaryAssessmentData: mockSetSupplementaryAssessmentData, handleSubmit: mockhandleSubmit, isReassessment: false }
+    const { queryAllByText, getByTestId } = render(
+      <Router>
+        <SupplementaryAnalystDetails
+          {...props}
+        />
+      </Router>
+    )
+
+    expect(mockSupplierInformationPropsTracker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isEditable: true
+      })
+    )
+
+    expect(mockZevSalesPropsTracker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isEditable: true
+      })
+    )
+
+    expect(mockCreditActivityPropsTracker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isEditable: true
+      })
+    )
+
+    expect(queryAllByText('CommentInputMock')).toHaveLength(2)
+
+    expect(mockCommentInputPropsTracker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Add comment to director: '
+      })
+    )
+
+    expect(mockCommentInputPropsTracker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'Assessment Message to the Supplier: '
+      })
+    )
+
+    radioDescriptions.forEach((radioDescription, index) => {
+      const id = radioDescription.id
+      const radioButton = getByTestId('recommendation-' + id)
+      fireEvent.click(radioButton)
+      expect(mockSetSupplementaryAssessmentData).toHaveBeenCalledTimes(index + 1)
+    })
+
+    const saveButton = getByTestId('save-button')
+    fireEvent.click(saveButton)
+    expect(mockhandleSubmit).toHaveBeenCalledWith('SUBMITTED', false)
+
+    const recommendButton = getByTestId('recommend-button')
+    fireEvent.click(recommendButton)
+    expect(mockhandleSubmit).toHaveBeenCalledWith('RECOMMENDED')
+
+    const returnButton = getByTestId('return-button')
+    fireEvent.click(returnButton)
+    expect(mockhandleSubmit).toHaveBeenCalledWith('DRAFT')
+  })
+
+  describe('as an analyst, if i view a supplemental report in any status, I should be able to view all 3 tabs', () => {
+    const statuses = ['DRAFT', 'SUBMITTED', 'RECOMMENDED', 'RETURNED', 'ASSESSED', 'REASSESSED']
+    statuses.forEach((status) => {
+      test('as an analyst, if i view a ' + status + ' supplemental report, I should be able to view all 3 tabs', () => {
+        const details = { ...baseDetails, actualStatus: status, status }
+        const props = { ...baseProps, details, supplementaryReportId: 1, isReassessment: false }
+        const { queryAllByText } = render(
+          <Router>
+            <SupplementaryAnalystDetails
+              {...props}
+            />
+          </Router>
+        )
+        expect(queryAllByText('SupplementaryTabMock')).toHaveLength(3)
+        expect(mockSupplementaryTabPropsTracker).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Supplementary Report',
+            disabled: false
+          })
+        )
+        expect(mockSupplementaryTabPropsTracker).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Reassessment Recommendation',
+            disabled: false
+          })
+        )
+        expect(mockSupplementaryTabPropsTracker).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Reassessment',
+            disabled: false
+          })
+        )
+      })
+    })
+  })
+
+  describe('as an analyst, if i view a supplemental report in recommended status under any tab, it should be read only', () => {
+    const tabs = ['supplemental', 'recommendation', 'reassessment']
+    const details = { ...baseDetails, actualStatus: 'RECOMMENDED', status: 'RECOMMENDED' }
+    tabs.forEach((tab) => {
+      test('as an analyst, if i view a supplemental report in recommended status and under tab ' + tab + ', it should be read-only', () => {
+        const props = { ...baseProps, details, query: { tab }, supplementaryReportId: 1, isReassessment: false }
+        render(
+          <Router>
+            <SupplementaryAnalystDetails
+              {...props}
+            />
+          </Router>
+        )
+        expect(mockSupplierInformationPropsTracker).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isEditable: false
+          })
+        )
+        expect(mockZevSalesPropsTracker).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isEditable: false
+          })
+        )
+        expect(mockCreditActivityPropsTracker).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isEditable: false
+          })
+        )
+      })
+    })
+  })
+
+  describe('as an analyst, if i view a supplemental report in submitted status under any tab, it should be editable', () => {
+    const tabs = ['supplemental', 'recommendation', 'reassessment']
+    const details = { ...baseDetails, actualStatus: 'SUBMITTED', status: 'SUBMITTED' }
+    tabs.forEach((tab) => {
+      test('as an analyst, if i view a supplemental report in submitted status and under tab ' + tab + ', it should be editable', () => {
+        const props = { ...baseProps, details, query: { tab }, supplementaryReportId: 1, isReassessment: false }
+        render(
+          <Router>
+            <SupplementaryAnalystDetails
+              {...props}
+            />
+          </Router>
+        )
+        expect(mockSupplierInformationPropsTracker).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isEditable: true
+          })
+        )
+        expect(mockZevSalesPropsTracker).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isEditable: true
+          })
+        )
+        expect(mockCreditActivityPropsTracker).toHaveBeenCalledWith(
+          expect.objectContaining({
+            isEditable: true
+          })
+        )
+      })
+    })
+  })
+
+  describe('as an analyst, if i view a reassessment report in any status, I should be able to view the second two tabs', () => {
+    const statuses = ['DRAFT', 'SUBMITTED', 'RECOMMENDED', 'RETURNED', 'ASSESSED', 'REASSESSED']
+    statuses.forEach((status) => {
+      test('as an analyst, if i view a ' + status + ' reassessment, I should be able to view the second two tabs', () => {
+        const details = { ...baseDetails, actualStatus: status, status }
+        const props = { ...baseProps, details, isReassessment: true }
+        const { queryAllByText } = render(
+          <Router>
+            <SupplementaryAnalystDetails
+              {...props}
+            />
+          </Router>
+        )
+        expect(queryAllByText('SupplementaryTabMock')).toHaveLength(2)
+        expect(mockSupplementaryTabPropsTracker).not.toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Supplementary Report'
+          })
+        )
+        expect(mockSupplementaryTabPropsTracker).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Reassessment Recommendation',
+            disabled: false
+          })
+        )
+        expect(mockSupplementaryTabPropsTracker).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: 'Reassessment',
+            disabled: false
+          })
+        )
+      })
+    })
+  })
 })
-// TESTS TO WRITE
-
-// as an analyst
-// if i view a supplemental report in submitted status
-// i should be able to edit fields, add comments to supplier or director,
-// click a radio button for the assessment, and save/recommend to director or return to supplier
-
-// as an analyst
-// if i view a supplemental report in recommended status
-// I should be able to view a read only version of all 3 tabs
-
-// as an analyst
-// if i view a supplemental report in any status
-// I should be able to view all 3 tabs
-
-// as an analyst
-// if i view a reassessment report in any status
-// I should be able to view the second two tabs
-
-// as an analyst
-// if i view a supplemental report in submitted status
-// I should be able to view a editable version of all 3 tabs

--- a/frontend/src/supplementary/components/__tests__/SupplementaryAnalystDetails.test.js
+++ b/frontend/src/supplementary/components/__tests__/SupplementaryAnalystDetails.test.js
@@ -340,11 +340,19 @@ describe('SupplementaryAnalystDetails', () => {
     })
   })
 
-  describe('as an analyst, if i view a supplemental report in submitted status under any tab, it should be editable', () => {
+  describe('as an analyst, if i view a supplemental report in submitted status, it should non-editable under the supplemental and reassessment tabs, and editable under the recommendation tab', () => {
     const tabs = ['supplemental', 'recommendation', 'reassessment']
     const details = { ...baseDetails, actualStatus: 'SUBMITTED', status: 'SUBMITTED' }
     tabs.forEach((tab) => {
-      test('as an analyst, if i view a supplemental report in submitted status and under tab ' + tab + ', it should be editable', () => {
+      let editable
+      if (tab === tabs[0]) {
+        editable = false
+      } else if (tab === tabs[1]) {
+        editable = true
+      } else if (tab === tabs[2]) {
+        editable = false
+      }
+      test(`as an analyst, if i view a supplemental report in submitted status and under the ${tab} tab, it should be${editable ? ' ' : ' not '}editable`, () => {
         const props = { ...baseProps, details, query: { tab }, supplementaryReportId: 1, isReassessment: false }
         render(
           <Router>
@@ -355,17 +363,17 @@ describe('SupplementaryAnalystDetails', () => {
         )
         expect(mockSupplierInformationPropsTracker).toHaveBeenCalledWith(
           expect.objectContaining({
-            isEditable: true
+            isEditable: editable
           })
         )
         expect(mockZevSalesPropsTracker).toHaveBeenCalledWith(
           expect.objectContaining({
-            isEditable: true
+            isEditable: editable
           })
         )
         expect(mockCreditActivityPropsTracker).toHaveBeenCalledWith(
           expect.objectContaining({
-            isEditable: true
+            isEditable: editable
           })
         )
       })


### PR DESCRIPTION
@AlexZorkin I'm not too sure about this test : // as an analyst
// if i view a supplemental report in submitted status
// I should be able to view a editable version of all 3 tabs

In the code, it looks like the "supplemental" and "reassessment" tabs should be non-editable when a supplemental report is in "submitted" status... I wrote the tests according to how they were described in the card, so the tests that deal with these 2 cases will fail.