### PR TITLE
fix: zeva 1567 reassessment penalty showing up as $0

### DIFF
--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -147,7 +147,7 @@ const SupplementaryAnalystDetails = (props) => {
                 details.assessmentData.legalName
               )
               .replace(/{modelYear}/g, details.assessmentData.modelYear)
-              .replace(/{penalty}/g, `$${formattedPenalty} CAD`)}
+              .replace(/{penalty}/g, `$${formatNumeric(supplementaryAssessmentData.supplementaryAssessment.assessmentPenalty, 0) || 0} CAD`)}
           </label>
         )}
       </div>

--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -79,8 +79,8 @@ const SupplementaryAnalystDetails = (props) => {
     ? details.actualStatus
     : details.status
 
+  const { supplementaryAssessment } = supplementaryAssessmentData
   const isAssessed = currentStatus === 'ASSESSED' || currentStatus === 'REASSESSED'
-  const supplementaryAssessment = supplementaryAssessmentData && supplementaryAssessmentData.supplementaryAssessment
 
   const tabNames = ['supplemental', 'recommendation', 'reassessment']
   const selectedTab = query?.tab ? query.tab : isAssessed ? tabNames[2] : tabNames[1]

--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -80,6 +80,7 @@ const SupplementaryAnalystDetails = (props) => {
     : details.status
 
   const isAssessed = currentStatus === 'ASSESSED' || currentStatus === 'REASSESSED'
+  const supplementaryAssessment = supplementaryAssessmentData && supplementaryAssessmentData.supplementaryAssessment
 
   const tabNames = ['supplemental', 'recommendation', 'reassessment']
   const selectedTab = query?.tab ? query.tab : isAssessed ? tabNames[2] : tabNames[1]
@@ -95,26 +96,24 @@ const SupplementaryAnalystDetails = (props) => {
   if (selectedTab === tabNames[2]) {
     isEditable = false
   }
-
   const assessmentDecision =
-    supplementaryAssessmentData.supplementaryAssessment.decision &&
-    supplementaryAssessmentData.supplementaryAssessment.decision.description
-      ? supplementaryAssessmentData.supplementaryAssessment.decision.description
+    supplementaryAssessment &&
+    supplementaryAssessment.decision &&
+    supplementaryAssessment.decision.description
+      ? supplementaryAssessment.decision.description
         .replace(
           /{user.organization.name}/g,
           details.assessmentData.legalName
         )
         .replace(/{modelYear}/g, details.assessmentData.modelYear)
-        .replace(/{penalty}/g, `$${formatNumeric(supplementaryAssessmentData.supplementaryAssessment.assessmentPenalty, 0) || 0} CAD`)
+        .replace(/{penalty}/g, `$${formatNumeric(supplementaryAssessment.assessmentPenalty, 0) || 0} CAD`)
       : ''
 
   const showDescription = (each) => {
     const selectedId =
-      supplementaryAssessmentData &&
-      supplementaryAssessmentData.supplementaryAssessment &&
-      supplementaryAssessmentData.supplementaryAssessment.decision &&
-      supplementaryAssessmentData.supplementaryAssessment.decision.id
-
+      supplementaryAssessment &&
+      supplementaryAssessment.decision &&
+      supplementaryAssessment.decision.id
     return (
       <div className="mb-3" key={each.id}>
         <input
@@ -147,7 +146,7 @@ const SupplementaryAnalystDetails = (props) => {
                 details.assessmentData.legalName
               )
               .replace(/{modelYear}/g, details.assessmentData.modelYear)
-              .replace(/{penalty}/g, `$${formatNumeric(supplementaryAssessmentData.supplementaryAssessment.assessmentPenalty, 0) || 0} CAD`)}
+              .replace(/{penalty}/g, `$${formatNumeric(supplementaryAssessment.assessmentPenalty, 0) || 0} CAD`)}
           </label>
         )}
       </div>
@@ -447,9 +446,9 @@ const SupplementaryAnalystDetails = (props) => {
             </div>
         )}
       </div>
-      {supplementaryAssessmentData.supplementaryAssessment &&
-        supplementaryAssessmentData.supplementaryAssessment.decision &&
-        supplementaryAssessmentData.supplementaryAssessment.decision.description &&
+      {supplementaryAssessment &&
+        supplementaryAssessment.decision &&
+        supplementaryAssessment.decision.description &&
           (['ASSESSED', 'RECOMMENDED'].indexOf(currentStatus) >= 0) && (
           <>
             <h3 className="mt-4 mb-1">Director Reassessment</h3>
@@ -506,8 +505,7 @@ const SupplementaryAnalystDetails = (props) => {
                             type="number"
                             className="ml-4 mr-1"
                             defaultValue={
-                              supplementaryAssessmentData
-                                .supplementaryAssessment.assessmentPenalty
+                              supplementaryAssessment.assessmentPenalty
                             }
                             name="penalty-amount"
                             onChange={(e) => {

--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -96,10 +96,6 @@ const SupplementaryAnalystDetails = (props) => {
     isEditable = false
   }
 
-  const formattedPenalty = details.assessment
-    ? formatNumeric(details.assessment.assessmentPenalty, 0)
-    : 0
-
   const assessmentDecision =
     supplementaryAssessmentData.supplementaryAssessment.decision &&
     supplementaryAssessmentData.supplementaryAssessment.decision.description
@@ -109,7 +105,7 @@ const SupplementaryAnalystDetails = (props) => {
           details.assessmentData.legalName
         )
         .replace(/{modelYear}/g, details.assessmentData.modelYear)
-        .replace(/{penalty}/g, `$${formattedPenalty} CAD`)
+        .replace(/{penalty}/g, `$${formatNumeric(supplementaryAssessmentData.supplementaryAssessment.assessmentPenalty, 0) || 0} CAD`)
       : ''
 
   const showDescription = (each) => {

--- a/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
@@ -95,9 +95,7 @@ const SupplementaryDirectorDetails = (props) => {
   }
 
 
-  const formattedPenalty = details.assessment
-    ? formatNumeric(details.assessment.assessmentPenalty, 0)
-    : 0
+
   const assessmentDecision =
     supplementaryAssessmentData.supplementaryAssessment.decision &&
     supplementaryAssessmentData.supplementaryAssessment.decision.description
@@ -107,7 +105,7 @@ const SupplementaryDirectorDetails = (props) => {
           details.assessmentData.legalName
         )
         .replace(/{modelYear}/g, details.assessmentData.modelYear)
-        .replace(/{penalty}/g, `$${formattedPenalty} CAD`)
+        .replace(/{penalty}/g, `$${formatNumeric(supplementaryAssessmentData.supplementaryAssessment.assessmentPenalty, 0) || 0} CAD`)
       : ''
   const showDescription = (each) => {
     const selectedId =
@@ -145,7 +143,7 @@ const SupplementaryDirectorDetails = (props) => {
                 details.assessmentData.legalName
               )
               .replace(/{modelYear}/g, details.assessmentData.modelYear)
-              .replace(/{penalty}/g, `$${formattedPenalty} CAD`)}
+              .replace(/{penalty}/g, `$${formatNumeric(supplementaryAssessmentData.supplementaryAssessment.assessmentPenalty, 0) || 0} CAD`)} CAD`)}
           </label>
         )}
       </div>

--- a/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
@@ -43,7 +43,6 @@ const SupplementaryDirectorDetails = (props) => {
     radioDescriptions,
     ratios,
     salesRows,
-    setSupplementaryAssessmentData,
     supplementaryAssessmentData,
     user,
     newData,
@@ -66,15 +65,16 @@ const SupplementaryDirectorDetails = (props) => {
   const [showModalDelete, setShowModalDelete] = useState(false)
   const reportYear = details.assessmentData && details.assessmentData.modelYear
   const supplierClass =
-    details.assessmentData && details.assessmentData.supplierClass[0]
+  details.assessmentData && details.assessmentData.supplierClass[0]
   const creditReductionSelection =
-    details.assessmentData && details.assessmentData.creditReductionSelection
+  details.assessmentData && details.assessmentData.creditReductionSelection
   let currentStatus = details.actualStatus
     ? details.actualStatus
     : details.status
   if (currentStatus === 'ASSESSED' && newReport) {
     currentStatus = 'DRAFT'
   }
+  const supplementaryAssessment = supplementaryAssessmentData && supplementaryAssessmentData.supplementaryAssessment
 
   const isAssessed =
     currentStatus === 'ASSESSED' || currentStatus === 'REASSESSED'
@@ -82,37 +82,35 @@ const SupplementaryDirectorDetails = (props) => {
   const isRecommended = currentStatus === 'RECOMMENDED'
 
   const tabNames = ['supplemental', 'recommendation', 'reassessment']
-  let selectedTab;
+  let selectedTab
 
   if (query?.tab) {
-    selectedTab = query.tab;
+    selectedTab = query.tab
   } else {
     if (isAssessed || isRecommended) {
-      selectedTab = tabNames[2];
+      selectedTab = tabNames[2]
     } else {
-      selectedTab = tabNames[1];
+      selectedTab = tabNames[1]
     }
   }
 
-
-
   const assessmentDecision =
-    supplementaryAssessmentData.supplementaryAssessment.decision &&
-    supplementaryAssessmentData.supplementaryAssessment.decision.description
-      ? supplementaryAssessmentData.supplementaryAssessment.decision.description
+    supplementaryAssessment &&
+    supplementaryAssessment.decision &&
+    supplementaryAssessment.decision.description
+      ? supplementaryAssessment.decision.description
         .replace(
           /{user.organization.name}/g,
           details.assessmentData.legalName
         )
         .replace(/{modelYear}/g, details.assessmentData.modelYear)
-        .replace(/{penalty}/g, `$${formatNumeric(supplementaryAssessmentData.supplementaryAssessment.assessmentPenalty, 0) || 0} CAD`)
+        .replace(/{penalty}/g, `$${formatNumeric(supplementaryAssessment.assessmentPenalty, 0) || 0} CAD`)
       : ''
   const showDescription = (each) => {
     const selectedId =
-      supplementaryAssessmentData &&
-      supplementaryAssessmentData.supplementaryAssessment &&
-      supplementaryAssessmentData.supplementaryAssessment.decision &&
-      supplementaryAssessmentData.supplementaryAssessment.decision.id
+      supplementaryAssessment &&
+      supplementaryAssessment.decision &&
+      supplementaryAssessment.decision.id
 
     return (
       <div className="mb-3" key={each.id}>
@@ -121,19 +119,7 @@ const SupplementaryDirectorDetails = (props) => {
           className="mr-3"
           type="radio"
           name="assessment"
-          disabled={true}
-          onChange={() => {
-            setSupplementaryAssessmentData({
-              ...supplementaryAssessmentData,
-              supplementaryAssessment: {
-                ...supplementaryAssessmentData.supplementaryAssessment,
-                decision: {
-                  description: each.description,
-                  id: each.id
-                }
-              }
-            })
-          }}
+          disabled={ true }
         />
         {each.description && (
           <label className="d-inline text-blue" htmlFor="complied">
@@ -143,7 +129,7 @@ const SupplementaryDirectorDetails = (props) => {
                 details.assessmentData.legalName
               )
               .replace(/{modelYear}/g, details.assessmentData.modelYear)
-              .replace(/{penalty}/g, `$${formatNumeric(supplementaryAssessmentData.supplementaryAssessment.assessmentPenalty, 0) || 0} CAD`)} CAD`)}
+              .replace(/{penalty}/g, `$${formatNumeric(supplementaryAssessment.assessmentPenalty, 0) || 0} CAD`)} CAD`)
           </label>
         )}
       </div>
@@ -530,19 +516,9 @@ const SupplementaryDirectorDetails = (props) => {
                             type="number"
                             className="ml-4 mr-1"
                             defaultValue={
-                              supplementaryAssessmentData
-                                .supplementaryAssessment.assessmentPenalty
+                              supplementaryAssessment.assessmentPenalty
                             }
                             name="penalty-amount"
-                            onChange={(e) => {
-                              setSupplementaryAssessmentData({
-                                ...supplementaryAssessmentData,
-                                supplementaryAssessment: {
-                                  ...supplementaryAssessmentData.supplementaryAssessment,
-                                  assessmentPenalty: e.target.value
-                                }
-                              })
-                            }}
                           />
                           <label className="text-grey" htmlFor="penalty-amount">
                             $5,000 CAD x ZEV unit deficit

--- a/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryDirectorDetails.js
@@ -74,7 +74,7 @@ const SupplementaryDirectorDetails = (props) => {
   if (currentStatus === 'ASSESSED' && newReport) {
     currentStatus = 'DRAFT'
   }
-  const supplementaryAssessment = supplementaryAssessmentData && supplementaryAssessmentData.supplementaryAssessment
+  const { supplementaryAssessment } = supplementaryAssessmentData
 
   const isAssessed =
     currentStatus === 'ASSESSED' || currentStatus === 'REASSESSED'
@@ -436,10 +436,9 @@ const SupplementaryDirectorDetails = (props) => {
             </div>
         )}
       </div>
-      {supplementaryAssessmentData.supplementaryAssessment &&
-        supplementaryAssessmentData.supplementaryAssessment.decision &&
-        supplementaryAssessmentData.supplementaryAssessment.decision
-          .description &&
+      {supplementaryAssessment &&
+        supplementaryAssessment.decision &&
+        supplementaryAssessment.decision.description &&
         ['ASSESSED', 'RECOMMENDED'].indexOf(currentStatus) >= 0 && (
           <>
             <h3 className="mt-4 mb-1">Director Reassessment</h3>


### PR DESCRIPTION
fix: updates logic so that penalty is displayed for director and analyst in the written description for recommended/assessed reports as well as radio descriptions (for draft, returned, etc)
chore: removes formattedPenalty to reduce amount of code
