### PR TITLE
fix: clear penalties when radio button changes - 1635 build-on-dev

### DIFF
--- a/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
+++ b/frontend/src/supplementary/components/SupplementaryAnalystDetails.js
@@ -133,7 +133,8 @@ const SupplementaryAnalystDetails = (props) => {
                 decision: {
                   description: each.description,
                   id: each.id
-                }
+                },
+                assessmentPenalty: ''
               }
             })
           }}
@@ -497,16 +498,14 @@ const SupplementaryAnalystDetails = (props) => {
                       <label className="d-inline" htmlFor="penalty-radio">
                         <div>
                           <input
-                            disabled={
-                              assessmentDecision.indexOf(
+                            disabled= {
+                              !assessmentDecision.includes(
                                 'Section 10 (3) applies'
-                              ) < 0
+                              )
                             }
                             type="number"
                             className="ml-4 mr-1"
-                            defaultValue={
-                              supplementaryAssessment.assessmentPenalty
-                            }
+                            value={supplementaryAssessment.assessmentPenalty || ''}
                             name="penalty-amount"
                             onChange={(e) => {
                               setSupplementaryAssessmentData({


### PR DESCRIPTION
when assessment is saved as draft with a penalty, that penalty is written to the database. Now any other radio selection will clear it from the box on the frontend, and if it is saved again or recommended, it will overwrite the original penalty 