### PR TITLE
Fix: Clear Penalties when Assessment decision changes - 1635

### DIFF
--- a/frontend/src/compliance/components/AssessmentDetailsPage.js
+++ b/frontend/src/compliance/components/AssessmentDetailsPage.js
@@ -143,7 +143,8 @@ const AssessmentDetailsPage = (props) => {
               decision: {
                 description: each.description,
                 id: each.id
-              }
+              },
+              assessmentPenalty: ''
             }
           })
         }}
@@ -507,9 +508,7 @@ const AssessmentDetailsPage = (props) => {
                               }
                               type="number"
                               className="ml-4 mr-1"
-                              defaultValue={
-                                details.assessment.assessmentPenalty
-                              }
+                              value={details.assessment.assessmentPenalty || ''}
                               name="penalty-amount"
                               onChange={(e) => {
                                 setDetails({


### PR DESCRIPTION
- Added logic on model year reports to clear the input field if the penalty radio button is not selected