### PR TITLE
Feat: Model Year Report Returned History Timestamp #1287

### DIFF
--- a/backend/api/serializers/model_year_report_noa.py
+++ b/backend/api/serializers/model_year_report_noa.py
@@ -231,7 +231,6 @@ class SupplementalModelYearReportSerializer(ModelSerializer):
         if request.user.is_government:
             history = history.exclude(
                 validation_status__in=[
-                    ModelYearReportStatuses.DRAFT,
                     ModelYearReportStatuses.DELETED,
                 ]
             )

--- a/frontend/src/compliance/components/ComplianceHistory.js
+++ b/frontend/src/compliance/components/ComplianceHistory.js
@@ -77,7 +77,7 @@ const ComplianceHistory = (props) => {
           // Checking to find any return to a supplier, we don't want to capture when a director returns to an analyst
           // The history reads from most recent to least recent so i + 1 to check the previous status
           // There is a case where the entry before a return is Recommended but it is correctly returned to a supplier so we also need to look at i - 1 to see if it is submitted
-          if(["RETURNED", "SUBMITTED"].includes(itemHistory[i + 1].status) && !reportType.includes("Reassessment") || itemHistory[i - 1]?.status === "SUBMITTED" && !reportType.includes("Reassessment")){
+          if(["RETURNED", "SUBMITTED"].includes(itemHistory[i + 1]?.status) && !reportType.includes("Reassessment") || itemHistory[i - 1]?.status === "SUBMITTED" && !reportType.includes("Reassessment")){
               tempHistory.push(obj)
           }
         }

--- a/frontend/src/compliance/components/ComplianceHistory.js
+++ b/frontend/src/compliance/components/ComplianceHistory.js
@@ -74,7 +74,7 @@ const ComplianceHistory = (props) => {
         if (
           ['RETURNED'].indexOf(obj.status) >= 0
         ) {
-          // Checking to find only the most recent return to a supplier, we don't want to capture when a director returns to an analyst
+          // Checking to find any return to a supplier, we don't want to capture when a director returns to an analyst
           // The history reads from most recent to least recent so i + 1 to check the previous status
           // There is a case where the entry before a return is Recommended but it is correctly returned to a supplier so we also need to look at i - 1 to see if it is submitted
           if(["RETURNED", "SUBMITTED"].includes(itemHistory[i + 1].status) && !reportType.includes("Reassessment") || itemHistory[i - 1]?.status === "SUBMITTED" && !reportType.includes("Reassessment")){

--- a/frontend/src/compliance/components/ComplianceHistory.js
+++ b/frontend/src/compliance/components/ComplianceHistory.js
@@ -28,28 +28,6 @@ const ComplianceHistory = (props) => {
     axios
       .get(ROUTES_COMPLIANCE.SUPPLEMENTAL_HISTORY.replace(/:id/g, id))
       .then((response) => {
-        response.data.forEach(report => {
-          let latestReturn = 0
-          let submitted = null
-          // Loop over report history to find the latest returned status to use as a starting point
-          for (let i = 0; i < report.history.length; i++) {
-            if (!report.history[i].status) {
-              continue
-            } else {
-              if (report.history[i].status === 'SUBMITTED') {
-                submitted = i
-              } else if (report.history[i].status === 'RETURNED') {
-                latestReturn = i
-              }
-            }
-          }
-          // If there is a return status, then filter out old entries but keep the original submission
-          if (latestReturn > 0) {
-            report.history.filter((value, index) => index === submitted || index >= latestReturn)
-          } else { // Otherwise use the original submission index as the starting point and remove anything prior if they exist
-            report.history.filter((value, index) => index >= submitted)
-          }
-        })
         setSupplementalReportHistory(response.data)
         response.data.forEach((report) => {
           if (report.isSupplementary === true) {
@@ -63,24 +41,46 @@ const ComplianceHistory = (props) => {
       })
   }, [])
 
-  const getHistory = (itemHistory) => {
+  const getHistory = (itemHistory, reportType) => {
     const tempHistory = []
     if (itemHistory) {
-      itemHistory.forEach((obj) => {
-        if (['SUBMITTED'].indexOf(obj.status) >= 0) {
-          const found = tempHistory.findIndex(
-            (each) => ['SUBMITTED'].indexOf(each.status) >= 0
-          )
-          if (found < 0) {
-            tempHistory.push(obj)
-          }
+      itemHistory.forEach((obj, i) => {
+        if(i === 0 && reportType.includes("Model Year Report")){
+          tempHistory.push(itemHistory[itemHistory.length - 1])
         }
         if (['DRAFT'].indexOf(obj.status) >= 0) {
           const found = tempHistory.findIndex(
             (each) => ['DRAFT'].indexOf(each.status) >= 0
           )
-          if (found < 0 && ['DRAFT', 'SUBMITTED'].includes(obj.status)) {
+          console.log(reportType)
+          // Check to see if a report has been returned to a draft status from submitted and if it has
+          // Then we need to modify the recorded object to correctly display the returned status instead of draft
+          // We also never capture returns in a reassessment because it is strictly internal
+          if (itemHistory[i + 1]?.status === "SUBMITTED" && !reportType.includes("Reassessment")){
+            let actuallyReturned = {...obj}
+            actuallyReturned.status = "RETURNED"
+            console.log(actuallyReturned, obj)
+            tempHistory.push(actuallyReturned)
+          }
+          else if (found < 0 && ['DRAFT', 'SUBMITTED'].includes(obj.status)){
             tempHistory.push(obj)
+          }
+        }
+        if (['SUBMITTED'].indexOf(obj.status) >= 0) {
+          // Check if a submitted history status comes after a returned/draft status or if there is nothing before it
+          // In both cases we capture the history entry as either it's been re-submitted, or it's the first submission
+          if(["RETURNED", "DRAFT"].includes(itemHistory[i + 1]?.status) || !itemHistory[i + 1]){
+            tempHistory.push(obj)
+          }
+        }
+        if (
+          ['RETURNED'].indexOf(obj.status) >= 0
+        ) {
+          // Checking to find only the most recent return to a supplier, we don't want to capture when a director returns to an analyst
+          // The history reads from most recent to least recent so i + 1 to check the previous status
+          // There is a case where the entry before a return is Recommended but it is correctly returned to a supplier so we also need to look at i - 1 to see if it is submitted
+          if(["RETURNED", "SUBMITTED"].includes(itemHistory[i + 1].status) && !reportType.includes("Reassessment") || itemHistory[i - 1]?.status === "SUBMITTED" && !reportType.includes("Reassessment")){
+              tempHistory.push(obj)
           }
         }
         if (
@@ -94,6 +94,11 @@ const ComplianceHistory = (props) => {
           }
         }
       })
+    }
+    // If we are in a model year report it will have a created status at the top
+    // Therefore we need to move the first entry to the end of the history array
+    if(reportType.includes("Model Year Report")){
+      tempHistory.push(tempHistory.shift())
     }
     return tempHistory
   }
@@ -256,7 +261,7 @@ const ComplianceHistory = (props) => {
                   <div className="card-body p-2">
                     <ul className="py-0 my-0 px-4">
                       {item.history &&
-                        getHistory(item.history).map((each, eachIndex) => (
+                        getHistory(item.history, getTitle(item)).map((each, eachIndex) => (
                           <li
                             id={`each-${eachIndex}`}
                             key={`each-${eachIndex}`}

--- a/frontend/src/compliance/components/ComplianceHistory.js
+++ b/frontend/src/compliance/components/ComplianceHistory.js
@@ -52,14 +52,12 @@ const ComplianceHistory = (props) => {
           const found = tempHistory.findIndex(
             (each) => ['DRAFT'].indexOf(each.status) >= 0
           )
-          console.log(reportType)
           // Check to see if a report has been returned to a draft status from submitted and if it has
           // Then we need to modify the recorded object to correctly display the returned status instead of draft
           // We also never capture returns in a reassessment because it is strictly internal
           if (itemHistory[i + 1]?.status === "SUBMITTED" && !reportType.includes("Reassessment")){
             let actuallyReturned = {...obj}
             actuallyReturned.status = "RETURNED"
-            console.log(actuallyReturned, obj)
             tempHistory.push(actuallyReturned)
           }
           else if (found < 0 && ['DRAFT', 'SUBMITTED'].includes(obj.status)){


### PR DESCRIPTION
- Removed exclude for draft statuses as a government user
- Added logic to properly capture when a report is returned to a supplier in the history.