### PR TITLE
Fix - Dashboard Link #1357

### DIFF
--- a/frontend/src/dashboard/components/ActionsBceid.js
+++ b/frontend/src/dashboard/components/ActionsBceid.js
@@ -197,7 +197,7 @@ const ActionsBceid = (props) => {
               icon="list"
               boldText="Credit Agreements"
               regularText={`${activityCount.creditAgreementsIssued} recorded by the Government of B.C.`}
-              linkTo={`${ROUTES_CREDIT_AGREEMENTS.LIST}?col-status=Issued`}
+              linkTo={`${ROUTES_CREDIT_AGREEMENTS.LIST}`}
             />
         )}
         {CONFIG.FEATURES.MODEL_YEAR_REPORT.ENABLED &&


### PR DESCRIPTION
- Updated dashboard link to not filter under a specific circumstance and instead link to the general list