### PR TITLE
Feat 2206 - Prevent commentator's name from displaying when updating information from comment

### DIFF
--- a/backend/api/serializers/sales_submission.py
+++ b/backend/api/serializers/sales_submission.py
@@ -469,7 +469,10 @@ class SalesSubmissionSerializer(
 
         if sales_submission_comment.exists():
             serializer = SalesSubmissionCommentSerializer(
-                sales_submission_comment, read_only=True, many=True
+                sales_submission_comment,
+                read_only=True,
+                many=True,
+                context={'request': request}
             )
             return serializer.data
 

--- a/backend/api/serializers/sales_submission_comment.py
+++ b/backend/api/serializers/sales_submission_comment.py
@@ -7,7 +7,6 @@ from api.models.user_profile import UserProfile
 from api.models.sales_submission_comment import SalesSubmissionComment
 from api.serializers.user import MemberSerializer
 
-
 class SalesSubmissionCommentSerializer(ModelSerializer):
     """
     Serializer for sales submission comments
@@ -15,12 +14,19 @@ class SalesSubmissionCommentSerializer(ModelSerializer):
     create_user = SerializerMethodField()
 
     def get_create_user(self, obj):
-        user = UserProfile.objects.filter(username=obj.create_user).first()
-        if user is None:
+        request = self.context.get('request')
+        commenting_user = UserProfile.objects.filter(username=obj.create_user).first()
+        if commenting_user is None:
             return obj.create_user
-
-        serializer = MemberSerializer(user, read_only=True)
-        return serializer.data
+        if not commenting_user.is_government or request.user.is_government:
+            ## if the commentor is not government or the request
+            #  user is government, show all the data
+            serializer = MemberSerializer(commenting_user, read_only=True)
+            return serializer.data
+        else:
+            #if the request user is not government and the commenter
+            #is government
+            return {'display_name': 'Government User'}
 
     def update(self, instance, validated_data):
         instance.comment = validated_data.get("comment")

--- a/backend/api/serializers/vehicle.py
+++ b/backend/api/serializers/vehicle.py
@@ -268,13 +268,14 @@ class VehicleSerializer(
         return obj.update_user
 
     def get_vehicle_comment(self, obj):
+        request = self.context.get('request')
         vehicle_comment = VehicleComment.objects.filter(
             vehicle=obj
         ).order_by('-create_timestamp')
 
         if vehicle_comment.exists():
             serializer = VehicleCommentSerializer(
-                vehicle_comment.first(), read_only=True
+                vehicle_comment.first(), read_only=True, context={'request': request}
             )
             return serializer.data
 

--- a/backend/api/serializers/vehicle_comment.py
+++ b/backend/api/serializers/vehicle_comment.py
@@ -15,12 +15,19 @@ class VehicleCommentSerializer(ModelSerializer):
     create_user = SerializerMethodField()
 
     def get_create_user(self, obj):
-        user = UserProfile.objects.filter(username=obj.create_user).first()
-        if user is None:
+        request = self.context.get('request')
+        commenting_user = UserProfile.objects.filter(username=obj.create_user).first()
+        if commenting_user is None:
             return obj.create_user
-
-        serializer = MemberSerializer(user, read_only=True)
-        return serializer.data
+        if not commenting_user.is_government or request.user.is_government:
+            ## if the commentor is not government or the request
+            #  user is government, show all the data
+            serializer = MemberSerializer(commenting_user, read_only=True)
+            return serializer.data
+        else:
+            #if the request user is not government and the commenter
+            #is government
+            return {'display_name': 'Government User'}
 
     class Meta:
         model = VehicleComment


### PR DESCRIPTION
removes commentors name from vehicle and credit requests

if commenter is idir and current user is bceid:
show 'government user'

if commenter is bcied or current user is idir:
show details