### PR TITLE
fix: supplementary comment not appearing, agreement alerts missing name of update user

### DIFF
--- a/backend/api/serializers/model_year_report_supplemental.py
+++ b/backend/api/serializers/model_year_report_supplemental.py
@@ -1,8 +1,8 @@
 from django.core.exceptions import ImproperlyConfigured
+from django.db.models import Q
 from enumfields.drf import EnumField
 from rest_framework.serializers import ModelSerializer, \
     SerializerMethodField, SlugRelatedField
-
 from api.models.supplemental_report import SupplementalReport
 from api.models.supplemental_report_sales import SupplementalReportSales
 from api.models.model_year_report_address import ModelYearReportAddress
@@ -316,10 +316,10 @@ class ModelYearReportSupplementalSerializer(UserSerializerMixin):
         return model_year_report.validation_status.value
 
     def get_from_supplier_comments(self, obj):
+        
         comments = SupplementalReportComment.objects.filter(
-            supplemental_report_id=obj.id
-        ).order_by('-create_timestamp')
-
+            Q(supplemental_report_id=obj.id) | Q(supplemental_report_id=obj.supplemental_id)
+                ).order_by('-create_timestamp')
         if comments.exists():
             serializer = ModelYearReportSupplementalCommentSerializer(comments, many=True)
             return serializer.data

--- a/backend/api/viewsets/model_year_report.py
+++ b/backend/api/viewsets/model_year_report.py
@@ -1230,7 +1230,6 @@ class ModelYearReportViewset(
 
     @action(detail=True, methods=["get"])
     def assessed_supplementals(self, request, pk):
-        print('::::::::', request)
         report = get_object_or_404(ModelYearReport, pk=pk)
         data = report.get_assessed_supplementals()
         serializer = ModelYearReportSupplementalSerializer(

--- a/frontend/src/creditagreements/components/CreditAgreementsAlert.js
+++ b/frontend/src/creditagreements/components/CreditAgreementsAlert.js
@@ -30,13 +30,13 @@ const CreditAgreementsAlert = (props) => {
   switch (status) {
     case 'DRAFT':
       title = 'Draft'
-      message = `saved, ${date} by ${typeof updateUser === 'string' ? updateUser : updateUser.firstName + " " + updateUser.lastName}.`
+      message = `saved, ${date} by ${updateUser.displayName}.`
       classname = 'alert-warning'
       break
 
     case 'RECOMMENDED':
       title = 'Recommended'
-      message = `recommended for issuance, ${date} by ${typeof updateUser === 'string' ? updateUser : updateUser.firstName + " " + updateUser.lastName}.`
+      message = `recommended for issuance, ${date} by ${updateUser.displayName}.`
       classname = 'alert-primary'
       break
 
@@ -72,7 +72,7 @@ CreditAgreementsAlert.defaultProps = {
 
 CreditAgreementsAlert.propTypes = {
   date: PropTypes.string.isRequired,
-  user: PropTypes.string.isRequired,
+  updateUser: PropTypes.shape().isRequired,
   status: PropTypes.string.isRequired,
   transactionType: PropTypes.string.isRequired,
   id: PropTypes.string.isRequired,

--- a/frontend/src/users/components/UserDetailsForm.js
+++ b/frontend/src/users/components/UserDetailsForm.js
@@ -100,7 +100,7 @@ const UserDetailsForm = (props) => {
               <div className="form-layout row">
                 <span className="col-md-8">
                   <TextInput
-                    defaultValue={details.firstName}
+                    defaultValue={details.firstName || ''}
                     errorMessage={
                       'firstName' in errorFields && errorFields.firstName
                     }
@@ -111,7 +111,7 @@ const UserDetailsForm = (props) => {
                     name="firstName"
                   />
                   <TextInput
-                    defaultValue={details.lastName}
+                    defaultValue={details.lastName || ''}
                     errorMessage={
                       'lastName' in errorFields && errorFields.lastName
                     }
@@ -122,7 +122,7 @@ const UserDetailsForm = (props) => {
                     name="lastName"
                   />
                   <TextInput
-                    defaultValue={details.title}
+                    defaultValue={details.title || ''}
                     errorMessage={'title' in errorFields && errorFields.title}
                     handleInputChange={handleInputChange}
                     id="jobTitle"
@@ -131,7 +131,7 @@ const UserDetailsForm = (props) => {
                     name="title"
                   />
                   <TextInput
-                    defaultValue={details.username}
+                    defaultValue={details.username || ''}
                     errorMessage={
                       'username' in errorFields && errorFields.username
                     }
@@ -142,7 +142,7 @@ const UserDetailsForm = (props) => {
                     name="username"
                   />
                   <TextInput
-                    defaultValue={details.keycloakEmail}
+                    defaultValue={details.keycloakEmail || ''}
                     details={
                       accountType === 'BCeID'
                         ? `the email associated with the ${accountType} account`
@@ -161,7 +161,7 @@ const UserDetailsForm = (props) => {
                     name="keycloakEmail"
                   />
                   <TextInput
-                    defaultValue={details.email}
+                    defaultValue={details.email || ''}
                     details="the email used to receive notifications, if different from above"
                     errorMessage={'email' in errorFields && errorFields.email}
                     handleInputChange={handleInputChange}
@@ -172,7 +172,7 @@ const UserDetailsForm = (props) => {
                   />
                   {accountType === 'BCeID' && (
                     <TextInput
-                      defaultValue={details.phone}
+                      defaultValue={details.phone || ''}
                       errorMessage={'phone' in errorFields && errorFields.phone}
                       handleInputChange={handleInputChange}
                       id="phone"


### PR DESCRIPTION
fix: updates credit agreement alert to use displayname
fix: grabs supplementary comments also using supplementary id instead of just reassessment id
chore: adds empty strings to default value in user details form so there are  no console errors if there are blank fields
chore: removes old print statement