### PR TITLE
fix: consumer LDV sales conditional display for report year < 2024

### DIFF
--- a/frontend/src/compliance/components/ConsumerLDVSales.js
+++ b/frontend/src/compliance/components/ConsumerLDVSales.js
@@ -32,7 +32,7 @@ const ConsumerLDVSales = (props) => {
       </div>
       <div className="row mb-3">
         <div className="col-5 text-blue">
-          {modelYear} {reportYear < 2024 ? "Model Year LDV Sales" : "Vehicles Supplied"}:
+          {modelYear} {modelYear < 2024 ? "Model Year LDV Sales" : "Vehicles Supplied"}:
         </div>
         <div className="col-3 text-right">{currentSales}</div>
         <div className="col-3 text-right">


### PR DESCRIPTION
replaces reportYear with modelYear so page can load properly (uncaught reference error)

the bug can be found as idir user going to submitted report, clicking assessment, and edit