### PR TITLE
ZEVA-1735: Unit tests for Credit Agreements

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,29 +1,30 @@
 module.exports = {
-  testEnvironment: 'jest-environment-jsdom',
-  collectCoverageFrom: ['src/**/*.{js,jsx}'],
-  coverageReporters: ['json'],
-  coverageThreshold: {
-    global: {
-      branches: 1,
-      functions: 1,
-      lines: 1,
-      statements: -6000
-    }
-  },
-  moduleFileExtensions: ['js', 'node', 'json'],
-  moduleNameMapper: {
-    '^.+\\.(css|less|scss)$': '<rootDir>/__mocks__/style.js'
-  },
-  setupFiles: ['./jest.setup.js'],
-  testEnvironmentOptions: {
-    url: 'http://localhost/'
-  },
-  transform: {
-    '^.+\\.(js|jsx)$': 'babel-jest'
-  },
-  coveragePathIgnorePatterns: ['node_modules/'],
-  verbose: true,
-  globals: {
-    __VERSION__: ''
-  }
+	testEnvironment: 'jest-environment-jsdom',
+	collectCoverageFrom: ['src/**/*.{js,jsx}'],
+	collectCoverageFrom: ["src/**/*.{js,jsx}"],
+	coverageReporters: ["json", "html", "lcov"],
+	coverageThreshold: {
+		global: {
+			branches: 1,
+			functions: 1,
+			lines: 1,
+			statements: -6000
+		}
+	},
+	moduleFileExtensions: ['js', 'node', 'json'],
+	testPathIgnorePatterns: ["/node_modules/", "/__tests__/test-data/"],
+	moduleNameMapper: {
+		'^.+\\.(css|less|scss)$': '<rootDir>/__mocks__/style.js'
+	},
+	setupFiles: ['./jest.setup.js'],
+	testEnvironmentOptions: {
+		url: 'http://localhost/'
+	},
+	transform: {
+		'^.+\\.(js|jsx)$': 'babel-jest'
+	},
+	verbose: true,
+	globals: {
+		__VERSION__: ''
+	}
 }

--- a/frontend/src/creditagreements/__tests__/CreditAgreementDetailsPage.test.js
+++ b/frontend/src/creditagreements/__tests__/CreditAgreementDetailsPage.test.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import CreditAgreementsDetailsPage from '../components/CreditAgreementsDetailsPage';
+import "@testing-library/jest-dom/extend-expect";
+import { CreditAgreementDetailsPageTestData } from './test-data/testData';
+import axios from 'axios';
+
+describe('CreditAgreementsDetailsPage', () => {
+	const { mockProps } = CreditAgreementDetailsPageTestData();
+	beforeEach(() => {
+		window.URL.createObjectURL = jest.fn(() => 'mockObjectURL');
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+	it("renders comments correctly", async () => {
+		render(<CreditAgreementsDetailsPage {...mockProps} />);
+		expect(screen.getByText(/lgtm/i)).toBeInTheDocument();
+	});
+
+	it("renders attachments correctly", async () => {
+		render(<CreditAgreementsDetailsPage {...mockProps} />);
+		expect(screen.getByText(/test.pdf/i)).toBeInTheDocument();
+	});
+
+	it("submit triggers modal, and confirm triggers handle submit", async () => {
+		render(<CreditAgreementsDetailsPage {...mockProps} />);
+		const submitButton = screen.getByText(/submit to director/i);
+		fireEvent.click(submitButton);
+
+		const confirmButton = screen.getByText(/^submit$/i);
+		fireEvent.click(confirmButton);
+
+		expect(mockProps.handleSubmit).toHaveBeenCalled();
+	});
+
+	it('calls handleAddComment when a comment is added', () => {
+		const { container, getByText } = render(<CreditAgreementsDetailsPage {...mockProps} />);
+
+		const input = container.querySelector('[data-link="https://quilljs.com"]');
+		fireEvent.change(input, { target: { value: 'New comment' } });
+		const addButton = getByText('Add Comment');
+		fireEvent.click(addButton);
+
+		expect(mockProps.handleAddComment).toHaveBeenCalled();
+	});
+
+	it("shows conditional text when whether issued or recommended is selected", async () => {
+		const { mockProps } = CreditAgreementDetailsPageTestData('ISSUED');
+		render(
+			<CreditAgreementsDetailsPage
+				{...mockProps}
+			/>
+		);
+		expect(
+			screen.getByText(/IA-1 issued.*by the Director/i)
+		).toBeInTheDocument();
+
+	});
+
+	it('renders agreement attachments and allows file download', async () => {
+		const { mockProps } = CreditAgreementDetailsPageTestData();
+		axios.get.mockResolvedValue({
+			data: new Blob(['test content'], { type: 'application/pdf' }),
+		});
+
+		render(<CreditAgreementsDetailsPage {...mockProps} />);
+
+		expect(screen.getByText(/test.pdf/i)).toBeInTheDocument();
+
+		const downloadButton = screen.getByText(/test.pdf/i);
+		fireEvent.click(downloadButton);
+
+		expect(axios.get).toHaveBeenCalledWith('/test.pdf', {
+			responseType: 'blob',
+			headers: { Authorization: null },
+		});
+	});
+
+
+});

--- a/frontend/src/creditagreements/__tests__/CreditAgreementDetailsTable.test.js
+++ b/frontend/src/creditagreements/__tests__/CreditAgreementDetailsTable.test.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CreditAgreementsDetailsTable from '../components/CreditAgreementsDetailsTable';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('CreditAgreementsDetailsTable', () => {
+	it('renders the table headers correctly', () => {
+		const items = [
+			{ numberOfCredits: 100, modelYear: '2024', creditClass: 'A' },
+			{ numberOfCredits: 50, modelYear: '2023', creditClass: 'B' },
+		];
+
+		render(<CreditAgreementsDetailsTable items={items} />);
+
+		expect(screen.getByText(/quantity/i)).toBeInTheDocument();
+		expect(screen.getByText(/model year/i)).toBeInTheDocument();
+		expect(screen.getByText(/zev class/i)).toBeInTheDocument();
+	});
+
+	it('renders the table rows correctly with provided data', () => {
+		const items = [
+			{ numberOfCredits: 1000, modelYear: '2024', creditClass: 'A' },
+			{ numberOfCredits: 2000, modelYear: '2023', creditClass: 'B' },
+		];
+
+		render(<CreditAgreementsDetailsTable items={items} />);
+
+		expect(screen.getByText('1,000.00')).toBeInTheDocument();
+		expect(screen.getByText('2024')).toBeInTheDocument();
+		expect(screen.getByText('A')).toBeInTheDocument();
+
+		expect(screen.getByText('2,000.00')).toBeInTheDocument();
+		expect(screen.getByText('2023')).toBeInTheDocument();
+		expect(screen.getByText('B')).toBeInTheDocument();
+	});
+
+	it('renders correctly when no data is provided', () => {
+		const items = [];
+		render(<CreditAgreementsDetailsTable items={items} />);
+		expect(screen.getByText(/no rows found/i)).toBeInTheDocument();
+	});
+
+	it('formats large numeric values correctly', () => {
+		const items = [
+			{ numberOfCredits: 1234567, modelYear: '2024', creditClass: 'C' },
+		];
+
+		render(<CreditAgreementsDetailsTable items={items} />);
+
+		expect(screen.getByText('1,234,567.00')).toBeInTheDocument();
+		expect(screen.getByText('2024')).toBeInTheDocument();
+		expect(screen.getByText('C')).toBeInTheDocument();
+	});
+});
+

--- a/frontend/src/creditagreements/__tests__/CreditAgreementsFilter.test.js
+++ b/frontend/src/creditagreements/__tests__/CreditAgreementsFilter.test.js
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CreditAgreementsFilter from '../components/CreditAgreementsFilter';
+import '@testing-library/jest-dom/extend-expect';
+import history from '../../app/History'; // Mock history
+import { CreditAgreementsFilterTestData } from './test-data/testData';
+
+jest.mock('../../app/History', () => ({
+	push: jest.fn(),
+}));
+
+jest.mock('../../app/utilities/getOptions', () =>
+	jest.fn(() => [
+		<option key="ISSUED" value="ISSUED">ISSUED</option>,
+		<option key="DRAFT" value="DRAFT">DRAFT</option>,
+	])
+);
+
+describe('CreditAgreementsFilter Component', () => {
+	const { mockProps } = CreditAgreementsFilterTestData;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('renders the supplier and status filters with correct options', () => {
+		const { container } = render(<CreditAgreementsFilter {...mockProps} />);
+
+		expect(container.querySelector('#col-supplier')).toBeInTheDocument();
+		expect(container.querySelector('#col-status')).toBeInTheDocument();
+		expect(screen.getByRole('option', { name: 'Supplier A' })).toBeInTheDocument();
+		expect(screen.getByRole('option', { name: 'Supplier B' })).toBeInTheDocument();
+		expect(screen.getByRole('option', { name: 'ISSUED' })).toBeInTheDocument();
+		expect(screen.getByRole('option', { name: 'DRAFT' })).toBeInTheDocument();
+	});
+
+	it('updates filters when a supplier is selected', () => {
+		const { container } = render(<CreditAgreementsFilter {...mockProps} />);
+
+		const supplierFilter = container.querySelector('#col-supplier');
+		fireEvent.change(supplierFilter, { target: { value: 'Supplier A' } });
+
+		expect(mockProps.setFiltered).toHaveBeenCalledWith(
+			expect.arrayContaining([
+				expect.objectContaining({ id: 'col-supplier', value: 'Supplier A' }),
+			])
+		);
+	});
+
+	it('updates filters when a status is selected', async () => {
+		const { container } = render(<CreditAgreementsFilter {...mockProps} />);
+		const statusFilter = container.querySelector('#col-status');
+
+		fireEvent.change(statusFilter, { target: { value: 'ISSUED' } });
+
+		expect(mockProps.setFiltered).toHaveBeenCalledWith(
+			expect.arrayContaining([
+				expect.objectContaining({ id: 'col-status', value: 'ISSUED' }),
+			])
+		);
+	});
+
+	it('calls handleClear when "Clear Filters" button is clicked', () => {
+		render(<CreditAgreementsFilter {...mockProps} />);
+
+		const clearButton = screen.getByRole('button', { name: /clear filters/i });
+		fireEvent.click(clearButton);
+
+		expect(mockProps.handleClear).toHaveBeenCalled();
+	});
+
+	it('renders "New Transaction" button for Government users but not for Directors', () => {
+		render(<CreditAgreementsFilter {...mockProps} />);
+
+		const newTransactionButton = screen.getByRole('button', { name: /new transaction/i });
+		expect(newTransactionButton).toBeInTheDocument();
+
+		fireEvent.click(newTransactionButton);
+		expect(history.push).toHaveBeenCalledWith('/credit-agreements/new');
+	});
+
+	it('does not render "New Transaction" button for Directors', () => {
+		const directorProps = {
+			...mockProps,
+			user: {
+				...mockProps.user,
+				roles: [{ roleCode: 'Director' }],
+			},
+		};
+
+		render(<CreditAgreementsFilter {...directorProps} />);
+
+		expect(screen.queryByText(/new transaction/i)).not.toBeInTheDocument();
+	});
+});
+

--- a/frontend/src/creditagreements/__tests__/test-data/testData.js
+++ b/frontend/src/creditagreements/__tests__/test-data/testData.js
@@ -1,0 +1,49 @@
+import moment from 'moment';
+import { jest } from '@jest/globals';
+
+export const CreditAgreementDetailsPageTestData = (status = "DRAFT") => ({
+	mockProps: {
+		analystAction: true,
+		directorAction: false,
+		details: {
+			transactionType: 'Credit Agreement',
+			updateTimestamp: moment().toISOString(),
+			updateUser: { id: 12345, displayName: 'Jonny' },
+			status: status,
+			filteredIdirComments: [
+				{ id: 1, comment: 'LGTM!', createUser: { id: '12345' }, user: { id: 1, name: 'Jonny' } },
+			],
+			filteredBceidComments: [],
+			creditAgreementContent: [],
+			attachments: [{ id: 1, filename: 'test.pdf', url: '/test.pdf' }],
+			optionalAgreementId: '12345',
+			effectiveDate: '2024-12-31',
+			organization: { name: 'Test Organization' },
+		},
+		handleAddComment: jest.fn(),
+		handleCommentChangeBceid: jest.fn(),
+		handleCommentChangeIdir: jest.fn(),
+		handleInternalCommentEdit: jest.fn(),
+		handleInternalCommentDelete: jest.fn(),
+		handleSubmit: jest.fn(),
+		id: '1',
+		user: { isGovernment: true },
+	},
+});
+
+export const CreditAgreementsFilterTestData = {
+	mockProps: {
+		user: {
+			isGovernment: true,
+			roles: [{ roleCode: 'Analyst' }],
+		},
+		items: [
+			{ organization: { name: 'Supplier A' }, status: 'DRAFT' },
+			{ organization: { name: 'Supplier B' }, status: 'ISSUED' },
+		],
+		filtered: [],
+		setFiltered: jest.fn(),
+		handleClear: jest.fn(),
+	},
+};
+


### PR DESCRIPTION
This ticket was to incorporate 3 unit tests for 3 different components in Credit Agreements.

The following tests benefit the following components:
![image](https://github.com/user-attachments/assets/0465124c-66fe-4155-aeac-d0f627cea4b1)
