### PR TITLE
fix: assessment edit bug 

### DIFF
--- a/frontend/src/compliance/components/ConsumerLDVSales.js
+++ b/frontend/src/compliance/components/ConsumerLDVSales.js
@@ -38,7 +38,7 @@ const ConsumerLDVSales = (props) => {
         <div className="col-3 text-right">
           <input
             className="text-right"
-            type="text"
+            type="number"
             onChange={(event) => {
               handleChangeSale(modelYear, event.target.value)
             }}


### PR DESCRIPTION
fix: changes sales input to be numerical instead of text to reduce user error

possibly the error was happening because the user added a comma into the input, now it will not accept non numeric values