### PR TITLE
fix: 2408 - confirmation checkbox for sales forecast

### DIFF
--- a/frontend/src/compliance/ConsumerSalesContainer.js
+++ b/frontend/src/compliance/ConsumerSalesContainer.js
@@ -33,8 +33,8 @@ const ConsumerSalesContainer = (props) => {
   const [forecastTotals, setForecastTotals] = useState({})
   const [saveTooltip, setSaveTooltip] = useState("");
   const [isSaveDisabled, setIsSaveDisabled] = useState(false);
+  const [salesForecastDisplay, setSalesForecastDisplay] = useState(false)
   const { id } = useParams()
-
   const refreshDetails = (showLoading) => {
     setLoading(showLoading)
 
@@ -79,7 +79,9 @@ const ConsumerSalesContainer = (props) => {
 
           setModelYear(year)
           setStatuses(reportStatuses)
-
+          if (modelYear >= 2023) {
+            setSalesForecastDisplay(true)
+          }
           if (['SAVED', 'UNSAVED'].indexOf(
             reportStatuses.consumerSales.status
           ) < 0){
@@ -168,13 +170,13 @@ const ConsumerSalesContainer = (props) => {
           (value) =>
             (typeof value === "number" || (!isNaN(value))) && value !== null
         )
-      ) && modelYear >= 2023) {
+      ) && salesForecastDisplay) {
         setSaveTooltip(
           "Please ensure forecast spreadsheet is uploaded and totals are filled out"
         );
         return true;
       }
-      setSaveTooltip(""); // Clear tooltip if no issues
+      setSaveTooltip(""); // Clear tooltip if conditions met
       return false;
     };
     setIsSaveDisabled(checkDisableSave());
@@ -216,6 +218,7 @@ const ConsumerSalesContainer = (props) => {
         setForecastTotals={setForecastTotals}
         saveTooltip={saveTooltip}
         isSaveDisabled={isSaveDisabled}
+        salesForecastDisplay={salesForecastDisplay}
       />
     </>
   )

--- a/frontend/src/compliance/components/ComplianceReportSignOff.js
+++ b/frontend/src/compliance/components/ComplianceReportSignOff.js
@@ -10,15 +10,21 @@ const ComplianceReportSignOff = (props) => {
     handleCheckboxClick,
     disabledCheckboxes,
     hoverText,
-    user
+    user,
+    salesForecastDisplay,
   } = props
-
   return (
     <div id="compliance-sign-off" className="my-3">
       <ReactTooltip />
       <div data-tip={hoverText}>
-        {assertions.map((assertion) => (
-            <div key={assertion.id}>
+        {assertions.filter((assertion) => {
+            if (!salesForecastDisplay && /forecast/i.test(assertion.description)) {
+              return false;
+            }
+            return true;
+          })
+          .map((assertion) => (
+          <div key={assertion.id}>
             <div className="d-inline-block align-middle my-2 ml-2 mr-1">
               <input
                 checked={
@@ -59,7 +65,8 @@ ComplianceReportSignOff.defaultProps = {
   assertions: [],
   checkboxes: [],
   disabledCheckboxes: '',
-  hoverText: ''
+  hoverText: '',
+  salesForecastDisplay: false,
 }
 ComplianceReportSignOff.propTypes = {
   assertions: PropTypes.arrayOf(PropTypes.shape()),
@@ -69,7 +76,8 @@ ComplianceReportSignOff.propTypes = {
   ),
   handleCheckboxClick: PropTypes.func.isRequired,
   hoverText: PropTypes.string,
-  disabledCheckboxes: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+  disabledCheckboxes: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  salesForecastDisplay: PropTypes.bool
 }
 
 export default ComplianceReportSignOff

--- a/frontend/src/compliance/components/ComplianceReportSignOff.js
+++ b/frontend/src/compliance/components/ComplianceReportSignOff.js
@@ -17,12 +17,8 @@ const ComplianceReportSignOff = (props) => {
     <div id="compliance-sign-off" className="my-3">
       <ReactTooltip />
       <div data-tip={hoverText}>
-        {assertions.filter((assertion) => {
-            if (!salesForecastDisplay && /forecast/i.test(assertion.description)) {
-              return false;
-            }
-            return true;
-          })
+        {assertions
+          .filter((assertion) => salesForecastDisplay || !/Forecast/i.test(assertion.description))
           .map((assertion) => (
           <div key={assertion.id}>
             <div className="d-inline-block align-middle my-2 ml-2 mr-1">

--- a/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
+++ b/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
@@ -37,7 +37,8 @@ const ConsumerSalesDetailsPage = (props) => {
     forecastTotals,
     setForecastTotals,
     saveTooltip,
-    isSaveDisabled
+    isSaveDisabled,
+    salesForecastDisplay
   } = props
 
   const [showModal, setShowModal] = useState(false)
@@ -185,7 +186,7 @@ const ConsumerSalesDetailsPage = (props) => {
               </div>
             </div>
           </div>
-          {modelYear >= 2023 &&
+          {salesForecastDisplay &&
             <div className="p-3 forecast-report">
               <label className="text-blue mr-4 font-weight-bold">
                 Forecast Report
@@ -220,6 +221,7 @@ const ConsumerSalesDetailsPage = (props) => {
           <div className="row">
             <div className="col-12 my-3">
             <ComplianceReportSignOff
+              salesForecastDisplay={salesForecastDisplay}
               assertions={assertions}
               checkboxes={checkboxes}
               handleCheckboxClick={handleCheckboxClick}

--- a/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
+++ b/frontend/src/compliance/components/ConsumerSalesDetailsPage.js
@@ -295,7 +295,8 @@ const ConsumerSalesDetailsPage = (props) => {
 }
 ConsumerSalesDetailsPage.defaultProps = {
   assertions: [],
-  checkboxes: []
+  checkboxes: [],
+  salesForecastDisplay: false,
 }
 
 ConsumerSalesDetailsPage.propTypes = {
@@ -320,5 +321,6 @@ ConsumerSalesDetailsPage.propTypes = {
   handleDelete: PropTypes.func.isRequired,
   saveTooltip: PropTypes.string.isRequired,
   isSaveDisabled: PropTypes.bool.isRequired,
+  salesForecastDisplay: PropTypes.bool,
 }
 export default ConsumerSalesDetailsPage


### PR DESCRIPTION
Forecast Report - checkbox only appears for MY2024 and later.

Consumer ZEV Sales Information - should remain

Older reports (MY2020–2022) don’t show the Forecast Report checkbox.