### PR TITLE
2439, 2440 Bug-fix: "year" at backend may not be int

### DIFF
--- a/backend/api/models/organization.py
+++ b/backend/api/models/organization.py
@@ -122,7 +122,7 @@ class Organization(Auditable):
         return sales
 
     def get_ldv_sales(self, year):
-        is_supplied = False if year < 2024 else True
+        is_supplied = False if int(year) < 2024 else True
         sales = self.ldv_sales.filter(
             model_year__name__in=[
                 str(year - 1),
@@ -138,7 +138,7 @@ class Organization(Auditable):
 
             if date.today().month < 10:
                 year -= 1
-        is_supplied = False if year < 2024 else True
+        is_supplied = False if int(year) < 2024 else True
 
         sales = self.ldv_sales.filter(
             model_year__name__lte=year

--- a/backend/api/models/organization.py
+++ b/backend/api/models/organization.py
@@ -145,6 +145,9 @@ class Organization(Auditable):
 
             if date.today().month < 10:
                 year -= 1
+        else:
+            year = int(year)  # Ensure year is an integer
+
         is_supplied = False if year < 2024 else True
         
         sales = self.filter_sales_supplied(year, is_supplied)[:3]


### PR DESCRIPTION
## Description of the bug:
After the supplier info page of the compliance report is saved as a draft, no further changed can be saved because the "patch" API would return status 500.  The reason behind is that the "year" is a string, which cannot be compared with the number 2024. (This mainly happen in line 141, but I changed the similar line 125 as well for save.)

This is related to the "red error message" described in #2440.
While the changes described in #2440 can prevent this bug being triggered, the solution also prevent user from saving a draft report. Hence, the changes proposed in #2440 (and related issue #2439) would need to be re-discussed among the PO, designer, and the business.