### PR TITLE
remove unused react keycloak

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,6 @@
     "react-dropzone": "^10.2.1",
     "react-hooks-testing-library": "^0.6.0",
     "react-hot-loader": "^4.12.18",
-    "react-keycloak": "^8.0.0-191118",
     "react-quill": "^1.3.5",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",


### PR DESCRIPTION
This PR removes the unused react-keycloak library, which breaks npm-install when declared alongside the updated keycloak-js library