### PR TITLE
fix overflowing tooltip

### DIFF
--- a/frontend/src/app/css/App.scss
+++ b/frontend/src/app/css/App.scss
@@ -391,6 +391,8 @@ button {
 .button-tooltip {
   max-width: 500px;
   opacity: 1;
+  white-space: normal;
+  overflow-wrap: break-word;
 }
 
 .center-horizontal-content {


### PR DESCRIPTION
Some tooltips were overflowing on a single line when it was over 500px, this ensures that it will break the word and flow down.