### PR TITLE
More cleanup for tooltips

### DIFF
--- a/frontend/src/app/components/Button.js
+++ b/frontend/src/app/components/Button.js
@@ -109,8 +109,14 @@ const Button = (props) => {
 
   return (
     <>
-      {tooltip && <ReactTooltip className="button-tooltip" multiline={true} />}
-      <span data-tip={tooltip}>
+      {tooltip && (
+        <ReactTooltip
+          className="button-tooltip"
+          multiline={true}
+          id="btn-tip"
+        />
+      )}
+      <span data-tip={tooltip} data-for="btn-tip">
         <button
           data-testid={testid}
           className={classname}

--- a/frontend/src/app/components/Tooltip.js
+++ b/frontend/src/app/components/Tooltip.js
@@ -23,6 +23,7 @@ const Tooltip = ({
       className="tooltip"
       place={placement}
       effect="solid"
+      html={true}
     />
     {/* react-fontawesome does not have the desired icon */}
     {infoCircle && (

--- a/frontend/src/app/css/App.scss
+++ b/frontend/src/app/css/App.scss
@@ -395,6 +395,7 @@ button {
   overflow: break-word !important;
   text-transform: none;
   text-align: left;
+  opacity: 1;
 }
 
 


### PR DESCRIPTION
- opacity back to 1
- remove html tags from being inside by adding `htm;={true}` to the `ReactTooltip`