### PR TITLE
Task: Disable Credit Application Delete Button From BCEID Side #2485

### DIFF
--- a/frontend/src/credits/components/CreditRequestDetailsPage.js
+++ b/frontend/src/credits/components/CreditRequestDetailsPage.js
@@ -576,7 +576,7 @@ const CreditRequestDetailsPage = (props) => {
               {(submission.validationStatus === 'DRAFT' ||
                 submission.validationStatus === 'REJECTED') &&
                 typeof user.hasPermission === 'function' &&
-                user.hasPermission('EDIT_SALES') && (
+                user.hasPermission('EDIT_SALES') && user.isGovernment && (
                   <Button
                     buttonType="delete"
                     action={() => {


### PR DESCRIPTION
Having some issues logging into the bceid accounts at the moment but I know this is high priority. So, this should be the fix for it but if possible someone should double check locally before merging it in.

- Disabling credit application delete button from BCEID side
