### PR TITLE
TASK: deleted submissions visible to IDIR users, deleted VINs no longer trigger duplicate warning

### DIFF
--- a/backend/api/services/sales_submission.py
+++ b/backend/api/services/sales_submission.py
@@ -329,6 +329,8 @@ def populate_already_awarded_warnings(
             if (
                 sale_record.submission.validation_status
                 != SalesSubmissionStatuses.REJECTED
+                and sale_record.submission.validation_status
+                != SalesSubmissionStatuses.DELETED
                 and sale_record.submission != content.submission
                 and sale_record.create_timestamp < content.update_timestamp
             ):

--- a/backend/api/viewsets/credit_request.py
+++ b/backend/api/viewsets/credit_request.py
@@ -73,7 +73,6 @@ class CreditRequestViewset(
             qs = SalesSubmission.objects.exclude(validation_status__in=(
                 SalesSubmissionStatuses.DRAFT,
                 SalesSubmissionStatuses.NEW,
-                SalesSubmissionStatuses.DELETED,
             ))
         else:
             qs = SalesSubmission.objects.filter(

--- a/frontend/src/credits/components/CreditRequestAlert.js
+++ b/frontend/src/credits/components/CreditRequestAlert.js
@@ -150,6 +150,17 @@ const CreditRequestAlert = (props) => {
         historyMessage = `${excelUploadMessage}.  ${submissionMessage}`
       }
       break
+    case 'DELETED':
+      title = 'Deleted'
+      message = `CA-${id} deleted  ${moment(
+        statusFilter('DELETED').createTimestamp
+      ).format('MMM D, YYYY')} by ${
+        statusFilter('DELETED').createUser.displayName}.`
+      classname = 'alert-warning'
+      if (excelUploadMessage) {
+        historyMessage = `${excelUploadMessage}.  ${submissionMessage}`
+      }
+      break
     default:
       title = ''
   }


### PR DESCRIPTION
task:
removes deleted records from exclusion filter in credit request) queryset so deleted submissions will show up for idir users. This may need to be modified as IDIR users might not want to see submissions that were Draft->Deleted.
updates populate_already_awarded_warnings funtion to  not include Deleted submissions when creating icbc warnings